### PR TITLE
WIP: Add constraint for PractitionerRole.identifier

### DIFF
--- a/input/resources/au-core-practitionerrole.xml
+++ b/input/resources/au-core-practitionerrole.xml
@@ -26,6 +26,18 @@
         </discriminator>
         <rules value="open"/>
       </slicing>
+      <condition value="au-core-prarol-02"/>
+      <constraint>
+          <key value="au-core-prarol-02"/>
+          <severity value="warning"/>
+          <human
+              value="HPI-I should be an attribute of Practitioner"/>
+          <expression
+              value="(PractitionerRole.identifier.type.coding.code contains 'NPI').not()"/>
+          <source
+              value="http://hl7.org.au/fhir/core/StructureDefinition/au-core-practitionerrole"
+          />
+      </constraint>
       <mustSupport value="true"/>
     </element>
     <element id="PractitionerRole.identifier:medicareProvider">


### PR DESCRIPTION
@heathfrankel mentioned that there is an issue with some test data.
For example here https://github.com/hl7au/au-fhir-core/blob/fac00908996b72c4aacb3c0d6e32a6f6e3cf5229/input/examples/practitionerrole-bobrester-bob-gp.xml#L22-L32 `PractitionerRole.identifier` contains HPI-I. 
While it should be on the `Practitioner.identifier`.
No restriction prevents such an identifier from being assigned.

I am proposing to add the constraint that checks that no HPI-I in `PractitionerRole.identifier`.