### PR TITLE
Update Downloads page 

### DIFF
--- a/input/pagecontent/downloads.md
+++ b/input/pagecontent/downloads.md
@@ -1,7 +1,7 @@
 
 ### Downloadable copy of entire specification
 
-A downloadable version of the entire implementation guide is available so it can be hosted locally:
+A downloadable version of the entire implementation guide is available so it can be hosted locally. To start exploring the guide, extract the files and open the index.html file in a web browser. This will provide access to the table of contents, introduction, and navigation links to different sections of the implementation guide.
 
 - [Downloadable Copy](full-ig.zip)
 
@@ -12,7 +12,7 @@ The following package file includes an NPM package file used by many of the FHIR
 - [R4 Package](package.tgz){::download="true"}
 - [R4B Package](package.r4b.tgz){::download="true"}
 
-See the overview on [validating FHIR profiles and resources](http://hl7.org/fhir/R4/validation.html) for more information about validating profiles and how to use these artefacts
+See the overview on [validating FHIR profiles and resources](http://hl7.org/fhir/R4/validation.html) for more information about validating profiles and how to use these artefacts.
 
 ### Examples 
 
@@ -21,6 +21,13 @@ All examples included in this implementation guide are available for download:
 - [XML](examples.xml.zip)
 - [JSON](examples.json.zip)
 - [TTL](examples.ttl.zip)
+
+### Consolidated CSV and Excel file representations of profiles 
+
+All the profile information for the {{site.data.fhir.ig.title}} in a single CSV or Excel file, which may be helpful to testers and analysts to review element properties across profiles in a single table:
+
+- [CSV(compressed folder)](csvs.zip)
+- [Excel(compressed folder)](excels.zip)
 
 ### Implementation Guide Details
 

--- a/input/pagecontent/downloads.md
+++ b/input/pagecontent/downloads.md
@@ -1,7 +1,9 @@
 
 ### Downloadable copy of entire specification
 
-A downloadable version of the entire implementation guide is available so it can be hosted locally. To start exploring the guide, extract the files and open the index.html file in a web browser. This will provide access to the table of contents, introduction, and navigation links to different sections of the implementation guide.
+A downloadable version of the entire implementation guide as a website is available so it can be hosted locally.
+
+It is not recommended to view locally without hosting, but you can extract the files and open the index.html file in a web browser. This will provide access to the table of contents, introduction, and navigation links to different sections of the implementation guide.
 
 - [Downloadable Copy](full-ig.zip)
 


### PR DESCRIPTION
Related to https://github.com/hl7au/au-fhir-core/issues/87. 

Updated downloads page to include additional information about the IG downloadable. 
Added a section and csv/excel downloadable files, this is now consistent with US Core. 

Some context around this
No changes in line of "use in an unintended fashion e.g. using internal files inside the downloaded site" as the csv/excel are provided for people that want to work with those specific formats. The tooling functionality to produce these is maintained by Grahame and the tooling team (many chats in chat.fhir.org about this). 
Terminology bindings are shown as 'canonical URL | FHIR version', which is consistent with the presentation in Terminology Bindings view in the IG. 
