### PR TITLE
Apply the rest of the changes for removal of support of HPI-I from PractitionerRole

### DIFF
--- a/input/intro-notes/StructureDefinition-au-core-practitionerrole-notes.md
+++ b/input/intro-notes/StructureDefinition-au-core-practitionerrole-notes.md
@@ -12,7 +12,7 @@
         <td>identifier</td>
         <td><b>SHALL</b></td>
         <td><code>token</code></td>
-        <td>The client <b>SHALL</b> provide at least a code value and <b>SHOULD</b> provide both the system and code values. The server <b>SHALL</b> support both. <br/><br/> The client <b>SHOULD</b> support search using HPI-I and Medicare Provider Number identifiers as defined in the profile. The server <b>SHOULD</b> support search using the using HPI-I and Medicare Provider Number identifiers as defined in the profile.</td>
+        <td>The client <b>SHALL</b> provide at least a code value and <b>SHOULD</b> provide both the system and code values. The server <b>SHALL</b> support both. <br/><br/> The client <b>SHOULD</b> support search using a Medicare Provider Number identifier as defined in the profile. The server <b>SHOULD</b> support search using a Medicare Provider Number identifier as defined in the profile.</td>
   </tr>
    <tr>
         <td>practitioner</td>
@@ -58,7 +58,6 @@ The following search parameters **SHALL** be supported:
 
     Example:
     
-      1. GET [base]/PractitionerRole?identifier=http://ns.electronichealth.net.au/id/hi/hpii/1.0\|8003619900015717
       1. GET [base]/PractitionerRole?identifier=http://ns.electronichealth.net.au/id/hi/hpii/1.0\|8003619900015717&amp;_include=PractitionerRole:practitioner
       1. GET [base]/PractitionerRole?identifier=http://ns.electronichealth.net.au/id/medicare-prescriber-number\|553255
 

--- a/input/intro-notes/StructureDefinition-au-core-practitionerrole-notes.md
+++ b/input/intro-notes/StructureDefinition-au-core-practitionerrole-notes.md
@@ -58,7 +58,7 @@ The following search parameters **SHALL** be supported:
 
     Example:
     
-      1. GET [base]/PractitionerRole?identifier=http://ns.electronichealth.net.au/id/hi/hpii/1.0\|8003619900015717&amp;_include=PractitionerRole:practitioner
+      1. GET [base]/PractitionerRole?identifier=http://ns.electronichealth.net.au/id/medicare-prescriber-number\|553255&amp;_include=PractitionerRole:practitioner
       1. GET [base]/PractitionerRole?identifier=http://ns.electronichealth.net.au/id/medicare-prescriber-number\|553255
 
     *Implementation Notes:* Fetches a bundle containing any PractitionerRole resources matching the identifier ([how to search by token](http://hl7.org/fhir/R4/search.html#token))

--- a/input/resources/au-core-client.xml
+++ b/input/resources/au-core-client.xml
@@ -4440,7 +4440,7 @@
 <name value="identifier"/>
 <definition value="http://hl7.org/fhir/SearchParameter/Practitioner-identifier"/>
 <type value="token"/>
-<documentation value="The client **SHALL** provide at least a code value and **MAY** provide both the system and code values. The server **SHALL** support both.&#xA;&#xA;The client **SHOULD** support search using a HPI-I identifier as defined in the profile. The server **SHOULD** support search using the using a HPI-I identifier as defined in the profile."/>
+<documentation value="The client **SHALL** provide at least a code value and **MAY** provide both the system and code values. The server **SHALL** support both.&#xA;&#xA;The client **SHOULD** support search using a HPI-I identifier as defined in the profile. The server **SHOULD** support search using a HPI-I identifier as defined in the profile."/>
 </searchParam>
 <searchParam>
 <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
@@ -4497,7 +4497,7 @@
 <name value="identifier"/>
 <definition value="http://hl7.org/fhir/SearchParameter/PractitionerRole-identifier"/>
 <type value="token"/>
-<documentation value="The client **SHALL** provide at least a code value and **MAY** provide both the system and code values. The server **SHALL** support both.&#xA;&#xA;The client **SHOULD** support search using HPI-I and Medicare Provider Number identifiers as defined in the profile. The server **SHOULD** support search using the using HPI-I and Medicare Provider Number identifiers as defined in the profile."/>
+<documentation value="The client **SHALL** provide at least a code value and **MAY** provide both the system and code values. The server **SHALL** support both.&#xA;&#xA;The client **SHOULD** support search using a Medicare Provider Number identifier as defined in the profile. The server **SHOULD** support search using a Medicare Provider Number identifier as defined in the profile."/>
 </searchParam>
 <searchParam>
 <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">

--- a/input/resources/au-core-server.xml
+++ b/input/resources/au-core-server.xml
@@ -2849,8 +2849,8 @@
   <div>
     <p>The client <strong>SHALL</strong> provide both the system and code values.</p>
     <p>The server <strong>SHALL</strong> support both.</p>
-    <p>The client <strong>SHOULD</strong> support search using a HPI-I identifier as defined in the profile.</p>
-    <p>The server <strong>SHOULD</strong> support search using a HPI-I identifier as defined in the profile.</p>
+    <p>The client <strong>SHOULD</strong> support search using a Medicare Provider Number identifier as defined in the profile.</p>
+    <p>The server <strong>SHOULD</strong> support search using a Medicare Provider Number identifier as defined in the profile.</p>
   </div>
 </td>
 </tr>
@@ -4535,7 +4535,7 @@
 <name value="identifier"/>
 <definition value="http://hl7.org/fhir/SearchParameter/PractitionerRole-identifier"/>
 <type value="token"/>
-<documentation value="The client **SHALL** provide at least a code value and **MAY** provide both the system and code values. The server **SHALL** support both.&#xA;&#xA;The client **SHOULD** support search using HPI-I and Medicare Provider Number identifiers as defined in the profile. The server **SHOULD** support search using the using HPI-I and Medicare Provider Number identifiers as defined in the profile."/>
+<documentation value="The client **SHALL** provide at least a code value and **MAY** provide both the system and code values. The server **SHALL** support both.&#xA;&#xA;The client **SHOULD** support search using a Medicare Provider Number identifier as defined in the profile. The server **SHOULD** support search using a Medicare Provider Number identifier as defined in the profile."/>
 </searchParam>
 <searchParam>
 <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">


### PR DESCRIPTION
Fixes https://github.com/hl7au/au-fhir-core/issues/127. 

Changes made: 

1. In PractitionerRole Notes
   - removed HPI-I from _identifier_ search parameter (it only requires searching by Medicare Provider Number as a SHOULD now)
 - removed example for as searching Practitioner Role by an IHI
2. Updated AU Core Client CapabilityStatement
3. Updated AU Core Server CapabilityStatement
 