### PR TITLE
Changes for aucore-blockvote-6 - search parameters

### DIFF
--- a/input/intro-notes/StructureDefinition-au-core-organization-notes.md
+++ b/input/intro-notes/StructureDefinition-au-core-organization-notes.md
@@ -71,7 +71,6 @@ The following search parameters **SHOULD** be supported:
     Example:
     
       1. GET [base]/Organization?name=Hospital
-      1. GET [base]/Organization?name=Hospital
 
     *Implementation Notes:* Fetches a bundle of all Organization resources matching the name ([how to search by string](http://hl7.org/fhir/R4/search.html#string))
     

--- a/input/intro-notes/StructureDefinition-au-core-organization-notes.md
+++ b/input/intro-notes/StructureDefinition-au-core-organization-notes.md
@@ -8,20 +8,20 @@
     <th>Requirements (when used alone or in combination)</th>
   </tr>
   <tr>
-        <td>address</td>
-        <td><b>SHALL</b></td>
-        <td><code>string</code></td>
-        <td></td>
-  </tr>
-  <tr>
         <td>identifier</td>
         <td><b>SHALL</b></td>
         <td><code>token</code></td>
         <td>The client <b>SHALL</b> provide at least a code value and <b>SHOULD</b> provide both the system and code values. The server <b>SHALL</b> support both. <br/><br/> The client <b>SHOULD</b> support search using HPI-O and ABN identifiers as defined in the profile. The server <b>SHOULD</b> support search using the using HPI-O and ABN identifiers as defined in the profile.</td>
   </tr>
   <tr>
+        <td>address</td>
+        <td><b>SHOULD</b></td>
+        <td><code>string</code></td>
+        <td></td>
+  </tr>
+  <tr>
         <td>name</td>
-        <td><b>SHALL</b></td>
+        <td><b>SHOULD</b></td>
         <td><code>string</code></td>
         <td></td>
   </tr>
@@ -38,16 +38,6 @@
 
 The following search parameters **SHALL** be supported:
 
-1. **SHALL** support searching for an organisation based on text address using the **[`address`](https://hl7.org/fhir/R4/organization.html#search)** search parameter:
-    
-    `GET [base]/Organization?address=[string]`
-
-    Example:
-    
-      1. GET [base]/Organization?address=QLD
-
-    *Implementation Notes:* Fetches a bundle of all Organization resources matching the address ([how to search by string](http://hl7.org/fhir/R4/search.html#string))
-
 1. **SHALL** support searching an organisation by an identifier using the **[`identifier`](https://hl7.org/fhir/R4/organization.html#search)** search parameter:
     
     `GET [base]/Organization?identifier={system|}[code]`
@@ -59,7 +49,22 @@ The following search parameters **SHALL** be supported:
 
     *Implementation Notes:* Fetches a bundle containing any Organization resources matching the identifier ([how to search by token](http://hl7.org/fhir/R4/search.html#token))
 
-1. **SHALL** support searching for an organisation based on text name using the **[`name`](https://hl7.org/fhir/R4/organization.html#search)** search parameter:
+
+#### Optional Search Parameters:
+
+The following search parameters **SHOULD** be supported:
+
+1. **SHOULD** support searching for an organisation based on text address using the **[`address`](https://hl7.org/fhir/R4/organization.html#search)** search parameter:
+    
+    `GET [base]/Organization?address=[string]`
+
+    Example:
+    
+      1. GET [base]/Organization?address=QLD
+
+    *Implementation Notes:* Fetches a bundle of all Organization resources matching the address ([how to search by string](http://hl7.org/fhir/R4/search.html#string))
+    
+1. **SHOULD** support searching for an organisation based on text name using the **[`name`](https://hl7.org/fhir/R4/organization.html#search)** search parameter:
     
     `GET [base]/Organization?name=[string]`
 
@@ -69,12 +74,7 @@ The following search parameters **SHALL** be supported:
       1. GET [base]/Organization?name=Hospital
 
     *Implementation Notes:* Fetches a bundle of all Organization resources matching the name ([how to search by string](http://hl7.org/fhir/R4/search.html#string))
-
-
-#### Optional Search Parameters:
-
-The following search parameters **SHOULD** be supported:
-
+    
 1. **SHOULD** support fetching an Organization using the **[`_id`](https://hl7.org/fhir/R4/organization.html#search)** search parameter:
     - **SHALL** support these **[`_revinclude`](http://hl7.org/fhir/R4/search.html#revinclude)** parameters: `Provenance:target`
     
@@ -86,3 +86,4 @@ The following search parameters **SHOULD** be supported:
       1. GET [base]/Organization?_id=5678&amp;_revinclude=Provenance:target
 
     *Implementation Notes:* Fetches a single Organization ([how to search by the logical id](http://hl7.org/fhir/R4/references.html#logical) of the resource)
+

--- a/input/intro-notes/StructureDefinition-au-core-patient-notes.md
+++ b/input/intro-notes/StructureDefinition-au-core-patient-notes.md
@@ -74,7 +74,7 @@
         <td>The client <b>SHALL</b> provide at least a code value and <b>MAY</b> provide both the system and code values. The server <b>SHALL</b> support both.</td>
   </tr>
   <tr>
-        <td>patient-gender-identity</td>
+        <td>gender-identity</td>
         <td><b>MAY</b></td>
         <td><code>token</code></td>
         <td>The client <b>SHALL</b> provide at least a code value and <b>MAY</b> provide both the system and code values. The server <b>SHALL</b> support both.</td>

--- a/input/pagecontent/changes.md
+++ b/input/pagecontent/changes.md
@@ -53,7 +53,7 @@ This change log documents the significant updates and resolutions implemented fr
 - Removed Must Support from the following elements in AU Core Waist Circumference: 
   - Observation.encounter [FHIR-45134](https://jira.hl7.org/browse/FHIR-45134)
   - Observation.performer [FHIR-44786](https://jira.hl7.org/browse/FHIR-44786)  
-- Corrected the search parameter for gender identity to be `gender-identity` not `patient-gender-identity` [FHIR-45057](https://jira.hl7.org/browse/FHIR-45057)
+- Corrected the search parameter for gender identity to be `gender-identity` not `patient-gender-identity` [FHIR-45057](https://jira.hl7.org/browse/FHIR-45057).
 - Changed the following Organization search parameters:
   - address search parameter to be SHOULD instead of SHALL [FHIR-45133](https://jira.hl7.org/browse/FHIR-45133)
   - name search parameter to be SHOULD instead of SHALL [FHIR-45133](https://jira.hl7.org/browse/FHIR-45133)

--- a/input/pagecontent/changes.md
+++ b/input/pagecontent/changes.md
@@ -53,3 +53,7 @@ This change log documents the significant updates and resolutions implemented fr
 - Removed Must Support from the following elements in AU Core Waist Circumference: 
   - Observation.encounter [FHIR-45134](https://jira.hl7.org/browse/FHIR-45134)
   - Observation.performer [FHIR-44786](https://jira.hl7.org/browse/FHIR-44786)  
+- Corrected the search parameter for gender identity to be `gender-identity` not `patient-gender-identity` [FHIR-45057](https://jira.hl7.org/browse/FHIR-45057)
+- Changed the following Organization search parameters:
+  - address search parameter to be SHOULD instead of SHALL [FHIR-45133](https://jira.hl7.org/browse/FHIR-45133)
+  - name search parameter to be SHOULD instead of SHALL [FHIR-45133](https://jira.hl7.org/browse/FHIR-45133)

--- a/input/resources/au-core-client.xml
+++ b/input/resources/au-core-client.xml
@@ -328,7 +328,7 @@
 </tr>
 <tr>
 <td>
-<a href="#Patient1-1">Organization</a>
+<a href="#Organization1-1">Organization</a>
 </td>
 <td>
 <a href="StructureDefinition-au-core-organization.html">http://hl7.org.au/fhir/core/StructureDefinition/au-core-organization</a>
@@ -355,7 +355,7 @@
 <td class="text-center">y</td>
 <td class="text-center"></td>
 <td class="text-center"></td>
-<td>_id, birthdate, birthdate+family, birthdate+name, family, family+gender, gender, gender+name, identifier, indigenous-status, name, patient-gender-identity</td>
+<td>_id, birthdate, birthdate+family, birthdate+name, family, family+gender, gender, gender+name, identifier, indigenous-status, name, gender-identity</td>
 <td/>
 <td>
 <code>Provenance:target</code>
@@ -2131,18 +2131,6 @@
   <b>SHALL</b>
 </td>
 <td>
-  <a href="http://hl7.org/fhir/R4/organization.html#search">address</a>
-</td>
-<td>
-  <code>string</code>
-</td>
-<td></td>
-</tr>
-<tr>
-<td>
-  <b>SHALL</b>
-</td>
-<td>
   <a href="http://hl7.org/fhir/R4/organization.html#search">identifier</a>
 </td>
 <td>
@@ -2159,7 +2147,19 @@
 </tr>
 <tr>
 <td>
-  <b>SHALL</b>
+  <b>SHOULD</b>
+</td>
+<td>
+  <a href="http://hl7.org/fhir/R4/organization.html#search">address</a>
+</td>
+<td>
+  <code>string</code>
+</td>
+<td></td>
+</tr>
+<tr>
+<td>
+  <b>SHOULD</b>
 </td>
 <td>
   <a href="http://hl7.org/fhir/R4/organization.html#search">name</a>
@@ -2380,7 +2380,7 @@
   <b>MAY</b>
 </td>
 <td>
-  <a href="http://hl7.org/fhir/R4/patient.html#search">patient-gender-identity</a>
+  <a href="https://build.fhir.org/ig/hl7au/au-fhir-base/search-parameters.html#patient">gender-identity</a>
 </td>
 <td>
   <code>token</code>
@@ -4506,8 +4506,8 @@
 <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
 <valueCode value="MAY"/>
 </extension>
-<name value="patient-gender-identity"/>
-<definition value="http://hl7.org.au/fhir/SearchParameter/patient-gender-identity"/>
+<name value="gender-identity"/>
+<definition value="http://hl7.org.au/fhir/SearchParameter/gender-identity"/>
 <type value="token"/>
 <documentation value="The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.&#xa;&#xa;The server **SHALL** support both."/>
 </searchParam>

--- a/input/resources/au-core-client.xml
+++ b/input/resources/au-core-client.xml
@@ -4300,7 +4300,7 @@
 </searchRevInclude>
 <searchParam>
 <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
-<valueCode value="SHALL"/>
+<valueCode value="SHOULD"/>
 </extension>
 <name value="address"/>
 <definition value="http://hl7.org/fhir/SearchParameter/Organization-address"/>
@@ -4317,7 +4317,7 @@
 </searchParam>
 <searchParam>
 <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
-<valueCode value="SHALL"/>
+<valueCode value="SHOULD"/>
 </extension>
 <name value="name"/>
 <definition value="http://hl7.org/fhir/SearchParameter/Organization-name"/>

--- a/input/resources/au-core-server.xml
+++ b/input/resources/au-core-server.xml
@@ -340,7 +340,7 @@
 </tr>
 <tr>
 <td>
-<a href="#Patient1-1">Organization</a>
+<a href="#Organization1-1">Organization</a>
 </td>
 <td>
 <a href="StructureDefinition-au-core-organization.html">http://hl7.org.au/fhir/core/StructureDefinition/au-core-organization</a>
@@ -367,7 +367,7 @@
 <td class="text-center">y</td>
 <td class="text-center"></td>
 <td class="text-center"></td>
-<td>_id, birthdate, birthdate+family, birthdate+name, family, family+gender, gender, gender+name, identifier, indigenous-status, name, patient-gender-identity</td>
+<td>_id, birthdate, birthdate+family, birthdate+name, family, family+gender, gender, gender+name, identifier, indigenous-status, name, gender-identity</td>
 <td/>
 <td>
 <code>Provenance:target</code>
@@ -2152,18 +2152,6 @@
   <b>SHALL</b>
 </td>
 <td>
-  <a href="http://hl7.org/fhir/R4/organization.html#search">address</a>
-</td>
-<td>
-  <code>string</code>
-</td>
-<td></td>
-</tr>
-<tr>
-<td>
-  <b>SHALL</b>
-</td>
-<td>
   <a href="http://hl7.org/fhir/R4/organization.html#search">identifier</a>
 </td>
 <td>
@@ -2180,7 +2168,19 @@
 </tr>
 <tr>
 <td>
-  <b>SHALL</b>
+  <b>SHOULD</b>
+</td>
+<td>
+  <a href="http://hl7.org/fhir/R4/organization.html#search">address</a>
+</td>
+<td>
+  <code>string</code>
+</td>
+<td></td>
+</tr>
+<tr>
+<td>
+  <b>SHOULD</b>
 </td>
 <td>
   <a href="http://hl7.org/fhir/R4/organization.html#search">name</a>
@@ -2400,7 +2400,7 @@
   <b>MAY</b>
 </td>
 <td>
-  <a href="http://hl7.org/fhir/R4/patient.html#search">patient-gender-identity</a>
+  <a href="https://build.fhir.org/ig/hl7au/au-fhir-base/search-parameters.html#patient">gender-identity</a>
 </td>
 <td>
   <code>token</code>
@@ -4312,7 +4312,7 @@
 </searchRevInclude>
 <searchParam>
 <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
-<valueCode value="SHALL"/>
+<valueCode value="SHOULD"/>
 </extension>
 <name value="address"/>
 <definition value="http://hl7.org/fhir/SearchParameter/Organization-address"/>
@@ -4329,7 +4329,7 @@
 </searchParam>
 <searchParam>
 <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
-<valueCode value="SHALL"/>
+<valueCode value="SHOULD"/>
 </extension>
 <name value="name"/>
 <definition value="http://hl7.org/fhir/SearchParameter/Organization-name"/>
@@ -4517,8 +4517,8 @@
 <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
 <valueCode value="MAY"/>
 </extension>
-<name value="patient-gender-identity"/>
-<definition value="http://hl7.org.au/fhir/SearchParameter/patient-gender-identity"/>
+<name value="gender-identity"/>
+<definition value="http://hl7.org.au/fhir/SearchParameter/gender-identity"/>
 <type value="token"/>
 <documentation value="The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.&#xa;&#xa;The server **SHALL** support both."/>
 </searchParam>


### PR DESCRIPTION
This PR addresses issues from the AU Core R1 Ballot for Comment aucore-blockvote-6: https://confluence.hl7.org/display/HAFWG/aucore-blockvote-6

- Corrected the search parameter for gender identity to be `gender-identity` not `patient-gender-identity` [FHIR-45057](https://jira.hl7.org/browse/FHIR-45057)
- Changed the following Organization search parameters:
  - address search parameter to be SHOULD instead of SHALL [FHIR-45133](https://jira.hl7.org/browse/FHIR-45133)
  - name search parameter to be SHOULD instead of SHALL [FHIR-45133](https://jira.hl7.org/browse/FHIR-45133)
- Updated change log