### PR TITLE
Changes for aucore-blockvote-15: AU Core Immunization

### DIFF
--- a/input/examples/immunization-covid-1.xml
+++ b/input/examples/immunization-covid-1.xml
@@ -49,16 +49,4 @@
 		</coding>
 		<text value="Intramuscular"/>
 	</route>
-	<protocolApplied>
-		<series value="primary vaccination course 2-dose"/>
-		<targetDisease>
-			<coding>
-				<system value="http://snomed.info/sct"/>
-				<code value="840539006"/>
-				<display value="COVID-19"/>
-			</coding>
-			<text value="COVID-19"/>
-		</targetDisease>
-		<doseNumberPositiveInt value="1"/>
-	</protocolApplied>
 </Immunization>

--- a/input/pagecontent/changes.md
+++ b/input/pagecontent/changes.md
@@ -8,6 +8,9 @@ This change log documents the significant updates and resolutions implemented fr
 #### Changes in this version
 
 - Added Security and Privacy page [FHIR-45067](https://jira.hl7.org/browse/FHIR-45067).
+- Made the following changes to AU Core Immunization:
+  - removed Must Support from Immunization.protocolApplied, Immunization.protocolApplied.series, Immunization.protocolApplied.targetDisease, Immunization.protocolApplied.doseNumber[x] [FHIR-44674](https://jira.hl7.org/browse/FHIR-44674), [FHIR-44656](https://jira.hl7.org/browse/FHIR-44656), [FHIR-44654](https://jira.hl7.org/browse/FHIR-44654)
+  - removed Must Support from Immunization.reasonCode [FHIR-45968](https://jira.hl7.org/browse/FHIR-45968)
 - Made the following changes to AU Core Encounter:
   - removed Must Support from Encounter.identifier [FHIR-45212](https://jira.hl7.org/browse/FHIR-45212)
   - removed Must Support from Encounter.type [FHIR-44580](https://jira.hl7.org/browse/FHIR-44580)

--- a/input/pagecontent/changes.md
+++ b/input/pagecontent/changes.md
@@ -10,7 +10,7 @@ This change log documents the significant updates and resolutions implemented fr
 - Added Security and Privacy page [FHIR-45067](https://jira.hl7.org/browse/FHIR-45067).
 - Made the following changes to AU Core Immunization:
   - removed Must Support from Immunization.protocolApplied, Immunization.protocolApplied.series, Immunization.protocolApplied.targetDisease, Immunization.protocolApplied.doseNumber[x] [FHIR-44674](https://jira.hl7.org/browse/FHIR-44674), [FHIR-44656](https://jira.hl7.org/browse/FHIR-44656), [FHIR-44654](https://jira.hl7.org/browse/FHIR-44654)
-  - removed Must Support from Immunization.reasonCode [FHIR-45968](https://jira.hl7.org/browse/FHIR-45968)
+  - removed Must Support from Immunization.reasonCode [FHIR-44654](https://jira.hl7.org/browse/FHIR-44654), [FHIR-45968](https://jira.hl7.org/browse/FHIR-45968)
 - Made the following changes to AU Core Encounter:
   - removed Must Support from Encounter.identifier [FHIR-45212](https://jira.hl7.org/browse/FHIR-45212)
   - removed Must Support from Encounter.type [FHIR-44580](https://jira.hl7.org/browse/FHIR-44580)

--- a/input/pagecontent/general-requirements.md
+++ b/input/pagecontent/general-requirements.md
@@ -358,7 +358,6 @@ AU Core Diagnostic Result Observation|Observation.effective[x]|dateTime, Period,
 AU Core Diagnostic Result Observation|Observation.value[x]|Quantity, CodeableConcept, string, boolean, integer, Range, Ratio, SampledData, time, Period
 AU Core Diagnostic Result Observation|Observation.component.value[x]|Quantity, CodeableConcept, string, boolean, integer, Range, Ratio, SampledData, time, Period
 AU Core Immunization|Immunization.occurrence[x]|dateTime, string
-AU Core Immunization|Immunization.doseNumber[x]|positiveInt, string
 AU Core MedicationRequest|MedicationRequest.medication[x]|CodeableConcept, Reference
 AU Core MedicationRequest|MedicationRequest.substitution.allowed[x]|boolean, CodeableConcept
 AU Core Procedure|Procedure.performed[x]|dateTime, Period, string, Age, Range

--- a/input/pagecontent/terminology.md
+++ b/input/pagecontent/terminology.md
@@ -44,7 +44,6 @@ The list below shows the value sets bound to a supported element or element slic
 - [Procedure](https://tx.ontoserver.csiro.au/fhir/ValueSet/procedure-1)
 - [RCPA SPIA Pathology Reporting](https://healthterminologies.gov.au/fhir/ValueSet/spia-pathology-reporting-1)
 - [Reason for Request](https://healthterminologies.gov.au/fhir/ValueSet/reason-for-request-1)
-- [Reason Vaccine Administered](https://healthterminologies.gov.au/fhir/ValueSet/reason-vaccine-administered-1)
 - [Service Type](https://healthterminologies.gov.au/fhir/ValueSet/service-type-1)
 - [Smoking Status](https://healthterminologies.gov.au/fhir/ValueSet/smoking-status-1)
 

--- a/input/pagecontent/terminology.md
+++ b/input/pagecontent/terminology.md
@@ -47,7 +47,6 @@ The list below shows the value sets bound to a supported element or element slic
 - [Reason Vaccine Administered](https://healthterminologies.gov.au/fhir/ValueSet/reason-vaccine-administered-1)
 - [Service Type](https://healthterminologies.gov.au/fhir/ValueSet/service-type-1)
 - [Smoking Status](https://healthterminologies.gov.au/fhir/ValueSet/smoking-status-1)
-- [Vaccination Target Disease](https://healthterminologies.gov.au/fhir/ValueSet/vaccination-target-disease-1) 
 
 **Value sets published in FHIR**
 - [AdministrativeGender](https://hl7.org/fhir/R4/valueset-administrative-gender.html)

--- a/input/resources/au-core-immunization.xml
+++ b/input/resources/au-core-immunization.xml
@@ -64,21 +64,5 @@
       <path value="Immunization.reasonCode"/>
       <mustSupport value="true"/>
     </element>
-    <element id="Immunization.protocolApplied">
-      <path value="Immunization.protocolApplied"/>
-      <mustSupport value="true"/>
-    </element>
-    <element id="Immunization.protocolApplied.series">
-      <path value="Immunization.protocolApplied.series"/>
-      <mustSupport value="true"/>
-    </element>
-    <element id="Immunization.protocolApplied.targetDisease">
-      <path value="Immunization.protocolApplied.targetDisease"/>
-      <mustSupport value="true"/>
-    </element>
-    <element id="Immunization.protocolApplied.doseNumber[x]">
-      <path value="Immunization.protocolApplied.doseNumber[x]"/>
-      <mustSupport value="true"/>
-    </element>
   </differential>
 </StructureDefinition>

--- a/input/resources/au-core-immunization.xml
+++ b/input/resources/au-core-immunization.xml
@@ -60,9 +60,5 @@
       <path value="Immunization.note"/>
       <mustSupport value="true"/>
     </element>
-    <element id="Immunization.reasonCode">
-      <path value="Immunization.reasonCode"/>
-      <mustSupport value="true"/>
-    </element>
   </differential>
 </StructureDefinition>


### PR DESCRIPTION
This PR addresses issues from the AU Core R1 Ballot for Comment aucore-blockvote-15:
https://confluence.hl7.org/display/HAFWG/aucore-blockvote-15 AND https://jira.hl7.org/browse/FHIR-45968.

- Made the following changes to the AU Core Immunization:
  - removed Must Support from Immunization.protocolApplied, Immunization.protocolApplied.series, Immunization.protocolApplied.targetDisease, Immunization.protocolApplied.doseNumber[x] [FHIR-44674](https://jira.hl7.org/browse/FHIR-44674), [FHIR-44656](https://jira.hl7.org/browse/FHIR-44656), [FHIR-44654](https://jira.hl7.org/browse/FHIR-44654)
  - removed Must Support from Immunization.reasonCode [FHIR-44654](https://jira.hl7.org/browse/FHIR-44654), [FHIR-45968](https://jira.hl7.org/browse/FHIR-45968)
- Updated 1 example to remove elements that are no longer Must Support
- Updated change log
- Updated general-requirements
- Updated terminology page to remove resources associated with elements that are no longer Must Support