### PR TITLE
AU Core MedicationRequest: remove Must Support from note & dispensing related elements

### DIFF
--- a/input/examples/medicationrequest-paracetamol-codeine.xml
+++ b/input/examples/medicationrequest-paracetamol-codeine.xml
@@ -56,32 +56,4 @@
             </doseQuantity>
         </doseAndRate>
     </dosageInstruction>
-    <dispenseRequest>
-        <dispenseInterval>
-            <value value="1"/>
-            <unit value="week"/>
-            <system value="http://unitsofmeasure.org"/>
-            <code value="wk"/>
-        </dispenseInterval>
-        <validityPeriod>
-            <start value="2018-07-15"/>
-            <end value="2019-07-15"/>
-        </validityPeriod>
-        <numberOfRepeatsAllowed value="2"/>
-        <quantity>
-            <value value="20"/>
-            <unit value="Tab"/>
-            <system value="http://terminology.hl7.org/CodeSystem/v3-orderableDrugForm"/>
-            <code value="TAB"/>
-        </quantity>
-        <expectedSupplyDuration>
-            <value value="10"/>
-            <unit value="days"/>
-            <system value="http://unitsofmeasure.org"/>
-            <code value="d"/>
-        </expectedSupplyDuration>
-    </dispenseRequest>
-    <substitution>
-        <allowedBoolean value="true"/>
-    </substitution>
 </MedicationRequest>

--- a/input/examples/medicationrequest-paracetamol-codeine.xml
+++ b/input/examples/medicationrequest-paracetamol-codeine.xml
@@ -28,9 +28,6 @@
         </coding>
         <text value="Pain management"/>
     </reasonCode>
-    <note>
-        <text value="Patient requires an administration aid."/>
-    </note>
     <dosageInstruction>
         <text value="1-2 tablets every 4-6 hours as needed for pain"/>
         <timing>

--- a/input/examples/medicationrequest-reaptan.xml
+++ b/input/examples/medicationrequest-reaptan.xml
@@ -51,32 +51,4 @@
             </doseQuantity>
         </doseAndRate>
     </dosageInstruction>
-    <dispenseRequest>
-        <dispenseInterval>
-            <value value="1"/>
-            <unit value="week"/>
-            <system value="http://unitsofmeasure.org"/>
-            <code value="wk"/>
-        </dispenseInterval>
-        <validityPeriod>
-            <start value="2018-07-15"/>
-            <end value="2019-07-15"/>
-        </validityPeriod>
-        <numberOfRepeatsAllowed value="2"/>
-        <quantity>
-            <value value="20"/>
-            <unit value="Tab"/>
-            <system value="http://terminology.hl7.org/CodeSystem/v3-orderableDrugForm"/>
-            <code value="TAB"/>
-        </quantity>
-        <expectedSupplyDuration>
-            <value value="10"/>
-            <unit value="days"/>
-            <system value="http://unitsofmeasure.org"/>
-            <code value="d"/>
-        </expectedSupplyDuration>
-    </dispenseRequest>
-    <substitution>
-        <allowedBoolean value="true"/>
-    </substitution>
 </MedicationRequest>

--- a/input/examples/medicationrequest-reaptan.xml
+++ b/input/examples/medicationrequest-reaptan.xml
@@ -23,9 +23,6 @@
     <reasonCode>
         <text value="Pain management"/>
     </reasonCode>
-    <note>
-        <text value="Patient requires an administration aid."/>
-    </note>
     <dosageInstruction>
         <text value="1-2 tablets every 4-6 hours as needed for pain"/>
         <timing>

--- a/input/pagecontent/changes.md
+++ b/input/pagecontent/changes.md
@@ -22,6 +22,7 @@ This change log documents the significant updates and resolutions implemented fr
   - in MedicationRequest.requester replaced RelatedPerson with AU Base RelatedPerson [FHIR-45228](https://jira.hl7.org/browse/FHIR-45228)
   - removed Must Support from MedicationRequest.identifier [FHIR-45208](https://jira.hl7.org/browse/FHIR-45208)
   - removed Must Support from MedicationRequest.category [FHIR-45207](https://jira.hl7.org/browse/FHIR-45207)
+  - removed Must Support from MedicationRequest.note [FHIR-45209](https://jira.hl7.org/browse/FHIR-45209)
   - added Must Support to MedicationRequest.reasonReference [FHIR-45090](https://jira.hl7.org/browse/FHIR-45090)
 - Made the following changes to AU Core Medication:
   - removal of Must Support from Medication.manufacturer [FHIR-45130](https://jira.hl7.org/browse/FHIR-45130)

--- a/input/pagecontent/changes.md
+++ b/input/pagecontent/changes.md
@@ -23,6 +23,8 @@ This change log documents the significant updates and resolutions implemented fr
   - removed Must Support from MedicationRequest.identifier [FHIR-45208](https://jira.hl7.org/browse/FHIR-45208)
   - removed Must Support from MedicationRequest.category [FHIR-45207](https://jira.hl7.org/browse/FHIR-45207)
   - removed Must Support from MedicationRequest.note [FHIR-45209](https://jira.hl7.org/browse/FHIR-45209)
+  - removed Must Support from MedicationRequest.dispenseRequest, MedicationRequest.dispenseRequest.validityPeriod, MedicationRequest.dispenseRequest.numberOfRepeatsAllowed, MedicationRequest.dispenseRequest.quantity [FHIR-45088](https://jira.hl7.org/browse/FHIR-45088)
+  - removed Must Support from MedicationRequest.substitution, MedicationRequest.substitution.allowed[x] [FHIR-45088](https://jira.hl7.org/browse/FHIR-45088)
   - added Must Support to MedicationRequest.reasonReference [FHIR-45090](https://jira.hl7.org/browse/FHIR-45090)
 - Made the following changes to AU Core Medication:
   - removal of Must Support from Medication.manufacturer [FHIR-45130](https://jira.hl7.org/browse/FHIR-45130)

--- a/input/pagecontent/general-requirements.md
+++ b/input/pagecontent/general-requirements.md
@@ -327,9 +327,9 @@ Complex elements are composed of primitive and/or other complex elements. Elemen
 
 For any complex element labelled as *Must Support*, an AU Core Responder **SHALL** be capable of providing at least one of the sub-element values. For some complex types a valid value can be constructed by populating only one sub-element, but usually more than one sub-element is needed. An AU Core Requestor **SHALL** be capable of processing the resource with all sub-elements.
 
-For example, the AU Core MedicationRequest Profile `note` element is labelled *Must Support* and has no *Must Support* sub-elements. When claiming conformance to this profile:
-- AU Core Responders **SHALL** be capable of providing a value in a `MedicationRequest.note` sub-element e.g. `MedicationRequest.note.text`.
-- AU Core Requestors **SHALL** be capable of processing the MedicationRequest resource with a value in `MedicationRequest.note`.
+For example, the AU Core Condition Profile `note` element is labelled *Must Support* and has no *Must Support* sub-elements. When claiming conformance to this profile:
+- AU Core Responders **SHALL** be capable of providing a value in a `Condition.note` sub-element e.g. `Condition.note.text`.
+- AU Core Requestors **SHALL** be capable of processing the Condition resource with a value in `Condition.note`.
 
 For example, if AU Core Patient Profile name element is labelled *Must Support* and has *Must Support* sub-elements "family” and “given”. When claiming conformance to this profile:
 - AU Core Responders **SHALL** be capable of providing a value in `Patient.name.family` and `Patient.name.given`.
@@ -360,7 +360,6 @@ AU Core Diagnostic Result Observation|Observation.value[x]|Quantity, CodeableCon
 AU Core Diagnostic Result Observation|Observation.component.value[x]|Quantity, CodeableConcept, string, boolean, integer, Range, Ratio, SampledData, time, Period
 AU Core Immunization|Immunization.occurrence[x]|dateTime, string
 AU Core MedicationRequest|MedicationRequest.medication[x]|CodeableConcept, Reference
-AU Core MedicationRequest|MedicationRequest.substitution.allowed[x]|boolean, CodeableConcept
 AU Core Procedure|Procedure.performed[x]|dateTime, Period, string, Age, Range
 {:.grid}
 

--- a/input/resources/au-core-medicationrequest.xml
+++ b/input/resources/au-core-medicationrequest.xml
@@ -129,29 +129,5 @@
       <path value="MedicationRequest.dosageInstruction"/>
       <mustSupport value="true"/>
     </element>
-    <element id="MedicationRequest.dispenseRequest">
-      <path value="MedicationRequest.dispenseRequest"/>
-      <mustSupport value="true"/>
-    </element>
-    <element id="MedicationRequest.dispenseRequest.validityPeriod">
-      <path value="MedicationRequest.dispenseRequest.validityPeriod"/>
-      <mustSupport value="true"/>
-    </element>
-    <element id="MedicationRequest.dispenseRequest.numberOfRepeatsAllowed">
-      <path value="MedicationRequest.dispenseRequest.numberOfRepeatsAllowed"/>
-      <mustSupport value="true"/>
-    </element>
-    <element id="MedicationRequest.dispenseRequest.quantity">
-      <path value="MedicationRequest.dispenseRequest.quantity"/>
-      <mustSupport value="true"/>
-    </element>
-    <element id="MedicationRequest.substitution">
-      <path value="MedicationRequest.substitution"/>
-      <mustSupport value="true"/>
-    </element>
-    <element id="MedicationRequest.substitution.allowed[x]">
-      <path value="MedicationRequest.substitution.allowed[x]"/>
-      <mustSupport value="true"/>
-    </element>
   </differential>
 </StructureDefinition>

--- a/input/resources/au-core-medicationrequest.xml
+++ b/input/resources/au-core-medicationrequest.xml
@@ -125,10 +125,6 @@
       </type>
       <mustSupport value="true"/>
     </element>
-    <element id="MedicationRequest.note">
-      <path value="MedicationRequest.note"/>
-      <mustSupport value="true"/>
-    </element>
     <element id="MedicationRequest.dosageInstruction">
       <path value="MedicationRequest.dosageInstruction"/>
       <mustSupport value="true"/>


### PR DESCRIPTION
This PR addresses: https://jira.hl7.org/browse/FHIR-45209, and https://jira.hl7.org/browse/FHIR-45088. 

Changes:
- updated StructureDefinition
- updated two examples to remove the elements that are no longer MS
- updated general-requirements
   - removed substitution.allowed[x] from Must Support - Choice of Data Types 
   - changed MedicationRequest.note example to Condition.note
- updated change log
