### PR TITLE
AU Core Vitals & Measurements: Remove Required Bindings to Metric Units (FHIR-44787)

### DIFF
--- a/input/pagecontent/changes.md
+++ b/input/pagecontent/changes.md
@@ -86,14 +86,17 @@ This change log documents the significant updates and resolutions implemented fr
   - removed Must Support from Observation.encounter [FHIR-45134](https://jira.hl7.org/browse/FHIR-45134)
   - removed Must Support from Observation.performer [FHIR-44786](https://jira.hl7.org/browse/FHIR-44786)
   - removed the fixed value constraint 'final' on Observation.status [FHIR-45120](https://jira.hl7.org/browse/FHIR-45120)
+  - removed the required binding to Metric Body Length Units value set from Observation.value[x]:valueQuantity to allow the FHIR standard profile binding, and added the Metric Body Length Units value set as a candidate additional binding [FHIR-44787](https://jira.hl7.org/browse/FHIR-44787)  
 - Made the following changes to AU Core Body Temperature: 
   - removed Must Support from Observation.encounter [FHIR-45134](https://jira.hl7.org/browse/FHIR-45134)
   - removed Must Support from Observation.performer [FHIR-44786](https://jira.hl7.org/browse/FHIR-44786) 
   - removed the fixed value constraint 'final' on Observation.status [FHIR-45120](https://jira.hl7.org/browse/FHIR-45120)
+  - removed the required binding to Metric Body Temperature Units value set from Observation.value[x]:valueQuantity to allow the FHIR standard profile binding, and added the Metric Body Temperature Units value set as a candidate additional binding [FHIR-44787](https://jira.hl7.org/browse/FHIR-44787) 
 - Made the following changes to AU Core Body Weight: 
   - removed Must Support from Observation.encounter [FHIR-45134](https://jira.hl7.org/browse/FHIR-45134)
   - removed Must Support from Observation.performer [FHIR-44786](https://jira.hl7.org/browse/FHIR-44786)
   - removed the fixed value constraint 'final' on Observation.status [FHIR-45120](https://jira.hl7.org/browse/FHIR-45120) 
+  - removed the required binding to Metric Body Weight Units value set from Observation.value[x]:valueQuantity to allow the FHIR standard profile binding, and added the Metric Body Weight Units value set as a candidate additional binding [FHIR-44787](https://jira.hl7.org/browse/FHIR-44787) 
 - Made the following changes to AU Core Heart Rate: 
   - removed Must Support from Observation.encounter [FHIR-45134](https://jira.hl7.org/browse/FHIR-45134)
   - removed Must Support from Observation.performer [FHIR-44786](https://jira.hl7.org/browse/FHIR-44786) 

--- a/input/resources/au-core-bodyheight.xml
+++ b/input/resources/au-core-bodyheight.xml
@@ -84,8 +84,16 @@
     <element id="Observation.value[x]:valueQuantity.code">
       <path value="Observation.value[x].code" />
       <binding>
-        <strength value="required" />
-        <valueSet value="https://healthterminologies.gov.au/fhir/ValueSet/metric-body-length-units-1" />
+        <extension url="http://hl7.org/fhir/tools/StructureDefinition/additional-binding">
+          <extension url="purpose">
+            <valueCode value="candidate"/>
+          </extension>
+          <extension url="valueSet">
+            <valueCanonical value="https://healthterminologies.gov.au/fhir/ValueSet/metric-body-length-units-1"/>
+          </extension>
+        </extension>
+        <strength value="required"/>
+        <valueSet value="http://hl7.org/fhir/ValueSet/ucum-bodylength"/>
       </binding>
     </element>
     <element id="Observation.dataAbsentReason">

--- a/input/resources/au-core-bodytemp.xml
+++ b/input/resources/au-core-bodytemp.xml
@@ -84,8 +84,16 @@
     <element id="Observation.value[x]:valueQuantity.code">
       <path value="Observation.value[x].code" />
       <binding>
-        <strength value="required" />
-        <valueSet value="https://healthterminologies.gov.au/fhir/ValueSet/metric-body-temperature-units-1" />
+        <extension url="http://hl7.org/fhir/tools/StructureDefinition/additional-binding">
+          <extension url="purpose">
+            <valueCode value="candidate"/>
+          </extension>
+          <extension url="valueSet">
+            <valueCanonical value="https://healthterminologies.gov.au/fhir/ValueSet/metric-body-temperature-units-1"/>
+          </extension>
+        </extension>
+        <strength value="required"/>
+        <valueSet value="http://hl7.org/fhir/ValueSet/ucum-bodytemp"/>
       </binding>
     </element>
     <element id="Observation.dataAbsentReason">

--- a/input/resources/au-core-bodyweight.xml
+++ b/input/resources/au-core-bodyweight.xml
@@ -84,8 +84,16 @@
     <element id="Observation.value[x]:valueQuantity.code">
       <path value="Observation.value[x].code" />
       <binding>
-        <strength value="required" />
-        <valueSet value="https://healthterminologies.gov.au/fhir/ValueSet/metric-body-weight-units-1" />
+        <extension url="http://hl7.org/fhir/tools/StructureDefinition/additional-binding">
+          <extension url="purpose">
+            <valueCode value="candidate"/>
+          </extension>
+          <extension url="valueSet">
+            <valueCanonical value="https://healthterminologies.gov.au/fhir/ValueSet/metric-body-weight-units-1"/>
+          </extension>
+        </extension>
+        <strength value="required"/>
+        <valueSet value="http://hl7.org/fhir/ValueSet/ucum-bodyweight"/>
       </binding>
     </element>
     <element id="Observation.dataAbsentReason">


### PR DESCRIPTION
This PR partly addresses https://jira.hl7.org/browse/FHIR-44787, voted in https://confluence.hl7.org/display/HAFWG/aucore-blockvote-16. 

PR includes changes for the following profiles: 
- AU Core Body Height
- AU Core Body Weight
- AU Core Body Temperature

JIRA https://jira.hl7.org/browse/FHIR-46031 has been raised to reach an agreement on a suitable binding for the AU Core Waist Circumference profile with the TDG. 



