### PR TITLE
AU Core Immunization: add MS to primarySource (FHIR-44659)

### DIFF
--- a/input/pagecontent/changes.md
+++ b/input/pagecontent/changes.md
@@ -10,8 +10,11 @@ This change log documents the significant updates and resolutions implemented fr
 - Added Security and Privacy page [FHIR-45067](https://jira.hl7.org/browse/FHIR-45067).
 - Moved the Medicine Information section from the General Guidance page to a new Medicine Information page [FHIR-45165](https://jira.hl7.org/browse/FHIR-45165).
 - Made the following changes to AU Core Immunization:
+  - removed Must Support from Immunization.encounter [FHIR-45218](https://jira.hl7.org/browse/FHIR-45218)
+  - removed Must Support from Immunization.performer, Immunization.performer.function, Immunization.performer.actor [FHIR-44653](https://jira.hl7.org/browse/FHIR-44653)
   - removed Must Support from Immunization.protocolApplied, Immunization.protocolApplied.series, Immunization.protocolApplied.targetDisease, Immunization.protocolApplied.doseNumber[x] [FHIR-44674](https://jira.hl7.org/browse/FHIR-44674), [FHIR-44656](https://jira.hl7.org/browse/FHIR-44656), [FHIR-44654](https://jira.hl7.org/browse/FHIR-44654)
   - removed Must Support from Immunization.reasonCode [FHIR-44654](https://jira.hl7.org/browse/FHIR-44654), [FHIR-45968](https://jira.hl7.org/browse/FHIR-45968)
+  - added Must Support to Immunization.primarySource [FHIR-44659](https://jira.hl7.org/browse/FHIR-44659)
 - Made the following changes to AU Core Encounter:
   - removed Must Support from Encounter.identifier [FHIR-45212](https://jira.hl7.org/browse/FHIR-45212)
   - removed Must Support from Encounter.type [FHIR-44580](https://jira.hl7.org/browse/FHIR-44580)
@@ -73,11 +76,6 @@ This change log documents the significant updates and resolutions implemented fr
   - removed Must Support from Observation.encounter [FHIR-45222](https://jira.hl7.org/browse/FHIR-45222)
   - removed Must Support from Observation.performer [FHIR-45223](https://jira.hl7.org/browse/FHIR-45223)
   - removed the fixed value constraint 'final' on Observation.status [FHIR-45120](https://jira.hl7.org/browse/FHIR-45120)
-- Removed Must Support from the following elements in AU Core Immunization:
-  - Immunization.encounter [FHIR-45218](https://jira.hl7.org/browse/FHIR-45218)
-  - Immunization.performer [FHIR-44653](https://jira.hl7.org/browse/FHIR-44653)
-  - Immunization.performer.function [FHIR-44653](https://jira.hl7.org/browse/FHIR-44653)
-  - Immunization.performer.actor [FHIR-44653](https://jira.hl7.org/browse/FHIR-44653)
 - Made the following changes to AU Core Blood Pressure: 
   - removed Must Support from Observation.encounter [FHIR-45134](https://jira.hl7.org/browse/FHIR-45134)
   - removed Must Support from Observation.performer [FHIR-44786](https://jira.hl7.org/browse/FHIR-44786)

--- a/input/resources/au-core-immunization.xml
+++ b/input/resources/au-core-immunization.xml
@@ -56,6 +56,10 @@
       <path value="Immunization.occurrence[x]"/>
       <mustSupport value="true"/>
     </element>
+    <element id="Immunization.primarySource">
+      <path value="Immunization.primarySource"/>
+      <mustSupport value="true"/>
+    </element>
     <element id="Immunization.note">
       <path value="Immunization.note"/>
       <mustSupport value="true"/>


### PR DESCRIPTION
This PR addresses https://jira.hl7.org/browse/FHIR-44659.

Changes:
- updated AU Core Immunization
- updated change log (including merging two AU Core Immunization entries)
 