### PR TITLE
AllergyIntolerance guidance clarification

### DIFF
--- a/input/examples/smokingstatus-current-smoker.xml
+++ b/input/examples/smokingstatus-current-smoker.xml
@@ -15,7 +15,7 @@
   <code>
    <coding>
       <system value="http://snomed.info/sct"/>
-      <code value="266918002" />
+      <code value="1747861000168109" />
     </coding>
     <coding>
       <system value="http://loinc.org"/>

--- a/input/intro-notes/StructureDefinition-au-core-allergyintolerance-intro.md
+++ b/input/intro-notes/StructureDefinition-au-core-allergyintolerance-intro.md
@@ -17,8 +17,10 @@ Conformance in reverse is not guaranteed, i.e. a resource conforming to [Interna
 
 
 ### Profile specific implementation guidance
-- `AllergyIntolerance.verificationStatus` is "unconfirmed" where a sending system does not clearly have this element or "confirmed" depending on the level of certainty
-- To represent that a patient does not have an allergy or category of allergies, an appropriate negation code (e.g. 716186003 \|No known allergy\| or 716184000 \|No known latex allergy\|) is used in `AllergyIntolerance.code`
-- The use of coding can vary significantly across systems, requesters need to understand that they may encounter codes they do not recognise and be prepared to handle those resources appropriately. Responders **SHOULD** populate `AllergyIntolerance.code.text` and/or `AllergyIntolerance.code.coding.display` so that requesters can at least display the condition even if the requester does not recognise the code supplied.
-- Refutation is not expected to be handled except as above - an appropriate negation code in `AllergyIntolerance.code` and `AllergyIntolerance.verificationStatus` of "confirmed" or "unconfirmed"
 - Where only substance is known (e.g. 111088007 \|Latex\|) and not a statement of allergy or intolerance (e.g. 300916003 \|Allergy to latex\|), the substance is sent in `AllergyIntolerance.code`
+- To represent that a patient does not have an allergy or category of allergies, an appropriate negation code (e.g. 716186003 \|No known allergy\| or 716184000 \|No known latex allergy\|) is used in `AllergyIntolerance.code`
+- The `verificationStatus` element is used to indicate certainty and **SHALL** be provided unless the clinicalStatus is "entered-in-error”. This is applicable for both allergies or intolerances and negated allergies or intolerances:
+  - "unconfirmed" is used when the allergy or negation is suspected but not yet confirmed due to a lack of clear evidence. The majority of allergy or intolerance records in some systems will use this status
+  - "confirmed" is used when the allergy or negation is validated with sufficient certainty, typically through clinical investigation
+- The use of coding can vary significantly across systems, requesters need to understand that they may encounter codes they do not recognise and be prepared to handle those resources appropriately. Responders **SHOULD** populate `AllergyIntolerance.code.text` and/or `AllergyIntolerance.code.coding.display` so that requesters can at least display the condition even if the requester does not recognise the code supplied.
+- AU Core currently does not provide guidance on the exchange of records for "refuted” allergies and intolerances but may do so in the future. Implementers are encouraged to consider the use of negation to communicate that a patient does not have an allergy or class of allergies

--- a/input/pagecontent/changes.md
+++ b/input/pagecontent/changes.md
@@ -90,6 +90,12 @@ This change log documents the significant updates and resolutions implemented fr
   - removed Must Support from Observation.encounter [FHIR-45222](https://jira.hl7.org/browse/FHIR-45222)
   - removed Must Support from Observation.performer [FHIR-45223](https://jira.hl7.org/browse/FHIR-45223)
   - removed the fixed value constraint 'final' on Observation.status [FHIR-45120](https://jira.hl7.org/browse/FHIR-45120)
+  - replaced Observation.code patternCodeableConcept constraint of 266918002 |Tobacco smoking consumption| with 1747861000168109 |Smoking status| [FHIR-45124](https://jira.hl7.org/browse/FHIR-45124) 
+- Removed Must Support from the following elements in AU Core Immunization:
+  - Immunization.encounter [FHIR-45218](https://jira.hl7.org/browse/FHIR-45218)
+  - Immunization.performer [FHIR-44653](https://jira.hl7.org/browse/FHIR-44653)
+  - Immunization.performer.function [FHIR-44653](https://jira.hl7.org/browse/FHIR-44653)
+  - Immunization.performer.actor [FHIR-44653](https://jira.hl7.org/browse/FHIR-44653)
 - Made the following changes to AU Core Blood Pressure: 
   - removed Must Support from Observation.encounter [FHIR-45134](https://jira.hl7.org/browse/FHIR-45134)
   - removed Must Support from Observation.performer [FHIR-44786](https://jira.hl7.org/browse/FHIR-44786)

--- a/input/resources/au-core-smokingstatus.xml
+++ b/input/resources/au-core-smokingstatus.xml
@@ -107,7 +107,7 @@
       <patternCodeableConcept>
         <coding>
           <system value="http://snomed.info/sct" />
-          <code value="266918002" />
+          <code value="1747861000168109" />
         </coding>
       </patternCodeableConcept>
       <mustSupport value="true"/>


### PR DESCRIPTION
Ballot - Accept the need to clarify the existing profile-specific implementation guidance to clarify representation of an allergy or intolerance statement that covers use of confirmed or unconfirmed and addresses negated