### PR TITLE
QA fixes - including FHIR-46035 & FHIR-45390

### DIFF
--- a/input/ig.xml
+++ b/input/ig.xml
@@ -41,6 +41,16 @@
 		<uri value="http://hl7.org/fhir/extensions/ImplementationGuide/hl7.fhir.uv.extensions"/>
 		<version value="5.1.0-snapshot1"/>
 	</dependsOn>
+	<dependsOn>
+		<uri value="http://hl7.org/fhir/smart-app-launch/ImplementationGuide/hl7.fhir.uv.smart-app-launch"/>
+		<packageId value="hl7.fhir.uv.smart-app-launch"/>
+		<version value="current"/>
+	</dependsOn>
+	<dependsOn>
+		<uri value="http://hl7.org/fhir/uv/ipa/ImplementationGuide/hl7.fhir.uv.ipa"/>
+		<packageId value="hl7.fhir.uv.ipa"/>
+		<version value="current"/>
+	</dependsOn>
 	<definition>
 		<resource>
 			<reference>

--- a/input/ig.xml
+++ b/input/ig.xml
@@ -862,5 +862,9 @@
 			<code value="path-expansion-params"/>
 			<value value="../input/_resources/exp-params.json"/>
 		</parameter>
+		<parameter>
+			<code value="fmm-definition"/>
+			<value value="https://build.fhir.org/ig/hl7au/au-fhir-base/guidance.html#maturity-levels"/>
+		</parameter>	
 	</definition>
 </ImplementationGuide>

--- a/input/ig.xml
+++ b/input/ig.xml
@@ -38,10 +38,6 @@
 		<version value="current"/>
 	</dependsOn>
 	<dependsOn>
-		<uri value="http://hl7.org/fhir/extensions/ImplementationGuide/hl7.fhir.uv.extensions"/>
-		<version value="5.1.0-snapshot1"/>
-	</dependsOn>
-	<dependsOn>
 		<uri value="http://hl7.org/fhir/smart-app-launch/ImplementationGuide/hl7.fhir.uv.smart-app-launch"/>
 		<packageId value="hl7.fhir.uv.smart-app-launch"/>
 		<version value="current"/>

--- a/input/ignoreWarnings.txt
+++ b/input/ignoreWarnings.txt
@@ -8,30 +8,3 @@ The HTML fragment 'globals-table.xhtml' is not included anywhere in the produced
 
 # CapabilityStatement warnings 
 This element does not match any known slice defined in the profile http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination|4.0.1
-
-# ================================================================================
-# ===  ERRORS ===
-# ===========================================================-=====================
-
-# ===  These errors are pending an update to the IG publisher for resolution; currently, there is no timeline for their correction. They are related by R4 and R5 value sets having different values, but using an R4 values returns the same error. See https://chat.fhir.org/#narrow/stream/179252-IG-creation/topic/QA.20error.20with.20ActorDefinition.20in.20R4.20IG ====
-ERROR: ActorDefinition/au-core-actor-requester: ActorDefinition.type: The value provided ('system') was not found in the value set 'Example Scenario Actor Type' (http://hl7.org/fhir/ValueSet/examplescenario-actor-type|5.0.0), and a code is required from this value set  (error message = The System URI could not be determined for the code 'system' in the ValueSet 'http://hl7.org/fhir/ValueSet/examplescenario-actor-type|5.0.0'; The provided code '#system' was not found in the value set 'http://hl7.org/fhir/ValueSet/examplescenario-actor-type|5.0.0')
-ERROR: ActorDefinition/au-core-actor-responder: ActorDefinition.type: The value provided ('system') was not found in the value set 'Example Scenario Actor Type' (http://hl7.org/fhir/ValueSet/examplescenario-actor-type|5.0.0), and a code is required from this value set  (error message = The System URI could not be determined for the code 'system' in the ValueSet 'http://hl7.org/fhir/ValueSet/examplescenario-actor-type|5.0.0'; The provided code '#system' was not found in the value set 'http://hl7.org/fhir/ValueSet/examplescenario-actor-type|5.0.0')
-
-
-# ===  These errors are pending an update to the IG publisher for resolution; currently, there is no timeline for their correction. See https://chat.fhir.org/#narrow/stream/179252-IG-creation/topic/QA.20errors.20with.20reprofiling.20extension.20from.205.2E1.2E0.20pack.20in.20r4 ====
-ERROR: StructureDefinition-au-core-rsg-sexassignedab.html: The reference integer64 could not be resolved
-ERROR: StructureDefinition-au-core-rsg-sexassignedab.html: The reference CodeableReference could not be resolved
-ERROR: StructureDefinition-au-core-rsg-sexassignedab.html: The reference RatioRange could not be resolved
-ERROR: StructureDefinition-au-core-rsg-sexassignedab.html: The reference Availability could not be resolved
-ERROR: StructureDefinition-au-core-rsg-sexassignedab.html: The reference ExtendedContactDetail could not be resolved
-ERROR: c:\work\git\au-fhir-core\output\StructureDefinition-au-core-rsg-sexassignedab-definitions.html#/html/body/div/div/div/div/div/div/div/table/tr/td/a at Line 499, column 1592: The link 'integer64.html' for "integer64" cannot be resolved
-ERROR: c:\work\git\au-fhir-core\output\StructureDefinition-au-core-rsg-sexassignedab-definitions.html#/html/body/div/div/div/div/div/div/div/table/tr/td/a at Line 499, column 3102: The link 'CodeableReference.html' for "CodeableReference" cannot be resolved
-ERROR: c:\work\git\au-fhir-core\output\StructureDefinition-au-core-rsg-sexassignedab-definitions.html#/html/body/div/div/div/div/div/div/div/table/tr/td/a at Line 499, column 4424: The link 'RatioRange.html' for "RatioRange" cannot be resolved
-ERROR: c:\work\git\au-fhir-core\output\StructureDefinition-au-core-rsg-sexassignedab-definitions.html#/html/body/div/div/div/div/div/div/div/table/tr/td/a at Line 499, column 5764: The link 'Availability.html' for "Availability" cannot be resolved
-ERROR: c:\work\git\au-fhir-core\output\StructureDefinition-au-core-rsg-sexassignedab-definitions.html#/html/body/div/div/div/div/div/div/div/table/tr/td/a at Line 499, column 5810: The link 'ExtendedContactDetail.html' for "ExtendedContactDetail" cannot be resolved
-ERROR: c:\work\git\au-fhir-core\output\StructureDefinition-au-core-rsg-sexassignedab-definitions.html#/html/body/div/div/div/div/div/div/div/table/tr/td/a at Line 679, column 1088: The link 'integer64.html' for "integer64" cannot be resolved
-ERROR: c:\work\git\au-fhir-core\output\StructureDefinition-au-core-rsg-sexassignedab-definitions.html#/html/body/div/div/div/div/div/div/div/table/tr/td/a at Line 679, column 2094: The link 'CodeableReference.html' for "CodeableReference" cannot be resolved
-ERROR: c:\work\git\au-fhir-core\output\StructureDefinition-au-core-rsg-sexassignedab-definitions.html#/html/body/div/div/div/div/div/div/div/table/tr/td/a at Line 679, column 2984: The link 'RatioRange.html' for "RatioRange" cannot be resolved
-ERROR: c:\work\git\au-fhir-core\output\StructureDefinition-au-core-rsg-sexassignedab-definitions.html#/html/body/div/div/div/div/div/div/div/table/tr/td/a at Line 679, column 3928: The link 'Availability.html' for "Availability" cannot be resolved
-ERROR: c:\work\git\au-fhir-core\output\StructureDefinition-au-core-rsg-sexassignedab-definitions.html#/html/body/div/div/div/div/div/div/div/table/tr/td/a at Line 679, column 3974: The link 'ExtendedContactDetail.html' for "ExtendedContactDetail" cannot be resolved
-

--- a/input/ignoreWarnings.txt
+++ b/input/ignoreWarnings.txt
@@ -5,6 +5,3 @@ The HTML fragment 'ip-statements.xhtml' is not included anywhere in the produced
 An HTML fragment from the set [cross-version-analysis.xhtml, cross-version-analysis-inline.xhtml] is not included anywhere in the produced implementation guide
 An HTML fragment from the set [dependency-table.xhtml, dependency-table-short.xhtml] is not included anywhere in the produced implementation guide
 The HTML fragment 'globals-table.xhtml' is not included anywhere in the produced implementation guide
-
-# CapabilityStatement warnings 
-This element does not match any known slice defined in the profile http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination|4.0.1

--- a/input/ignoreWarnings.txt
+++ b/input/ignoreWarnings.txt
@@ -8,3 +8,30 @@ The HTML fragment 'globals-table.xhtml' is not included anywhere in the produced
 
 # CapabilityStatement warnings 
 This element does not match any known slice defined in the profile http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination|4.0.1
+
+# ================================================================================
+# ===  ERRORS ===
+# ===========================================================-=====================
+
+# ===  These errors are pending an update to the IG publisher for resolution; currently, there is no timeline for their correction. They are related by R4 and R5 value sets having different values, but using an R4 values returns the same error. See https://chat.fhir.org/#narrow/stream/179252-IG-creation/topic/QA.20error.20with.20ActorDefinition.20in.20R4.20IG ====
+ERROR: ActorDefinition/au-core-actor-requester: ActorDefinition.type: The value provided ('system') was not found in the value set 'Example Scenario Actor Type' (http://hl7.org/fhir/ValueSet/examplescenario-actor-type|5.0.0), and a code is required from this value set  (error message = The System URI could not be determined for the code 'system' in the ValueSet 'http://hl7.org/fhir/ValueSet/examplescenario-actor-type|5.0.0'; The provided code '#system' was not found in the value set 'http://hl7.org/fhir/ValueSet/examplescenario-actor-type|5.0.0')
+ERROR: ActorDefinition/au-core-actor-responder: ActorDefinition.type: The value provided ('system') was not found in the value set 'Example Scenario Actor Type' (http://hl7.org/fhir/ValueSet/examplescenario-actor-type|5.0.0), and a code is required from this value set  (error message = The System URI could not be determined for the code 'system' in the ValueSet 'http://hl7.org/fhir/ValueSet/examplescenario-actor-type|5.0.0'; The provided code '#system' was not found in the value set 'http://hl7.org/fhir/ValueSet/examplescenario-actor-type|5.0.0')
+
+
+# ===  These errors are pending an update to the IG publisher for resolution; currently, there is no timeline for their correction. See https://chat.fhir.org/#narrow/stream/179252-IG-creation/topic/QA.20errors.20with.20reprofiling.20extension.20from.205.2E1.2E0.20pack.20in.20r4 ====
+ERROR: StructureDefinition-au-core-rsg-sexassignedab.html: The reference integer64 could not be resolved
+ERROR: StructureDefinition-au-core-rsg-sexassignedab.html: The reference CodeableReference could not be resolved
+ERROR: StructureDefinition-au-core-rsg-sexassignedab.html: The reference RatioRange could not be resolved
+ERROR: StructureDefinition-au-core-rsg-sexassignedab.html: The reference Availability could not be resolved
+ERROR: StructureDefinition-au-core-rsg-sexassignedab.html: The reference ExtendedContactDetail could not be resolved
+ERROR: c:\work\git\au-fhir-core\output\StructureDefinition-au-core-rsg-sexassignedab-definitions.html#/html/body/div/div/div/div/div/div/div/table/tr/td/a at Line 499, column 1592: The link 'integer64.html' for "integer64" cannot be resolved
+ERROR: c:\work\git\au-fhir-core\output\StructureDefinition-au-core-rsg-sexassignedab-definitions.html#/html/body/div/div/div/div/div/div/div/table/tr/td/a at Line 499, column 3102: The link 'CodeableReference.html' for "CodeableReference" cannot be resolved
+ERROR: c:\work\git\au-fhir-core\output\StructureDefinition-au-core-rsg-sexassignedab-definitions.html#/html/body/div/div/div/div/div/div/div/table/tr/td/a at Line 499, column 4424: The link 'RatioRange.html' for "RatioRange" cannot be resolved
+ERROR: c:\work\git\au-fhir-core\output\StructureDefinition-au-core-rsg-sexassignedab-definitions.html#/html/body/div/div/div/div/div/div/div/table/tr/td/a at Line 499, column 5764: The link 'Availability.html' for "Availability" cannot be resolved
+ERROR: c:\work\git\au-fhir-core\output\StructureDefinition-au-core-rsg-sexassignedab-definitions.html#/html/body/div/div/div/div/div/div/div/table/tr/td/a at Line 499, column 5810: The link 'ExtendedContactDetail.html' for "ExtendedContactDetail" cannot be resolved
+ERROR: c:\work\git\au-fhir-core\output\StructureDefinition-au-core-rsg-sexassignedab-definitions.html#/html/body/div/div/div/div/div/div/div/table/tr/td/a at Line 679, column 1088: The link 'integer64.html' for "integer64" cannot be resolved
+ERROR: c:\work\git\au-fhir-core\output\StructureDefinition-au-core-rsg-sexassignedab-definitions.html#/html/body/div/div/div/div/div/div/div/table/tr/td/a at Line 679, column 2094: The link 'CodeableReference.html' for "CodeableReference" cannot be resolved
+ERROR: c:\work\git\au-fhir-core\output\StructureDefinition-au-core-rsg-sexassignedab-definitions.html#/html/body/div/div/div/div/div/div/div/table/tr/td/a at Line 679, column 2984: The link 'RatioRange.html' for "RatioRange" cannot be resolved
+ERROR: c:\work\git\au-fhir-core\output\StructureDefinition-au-core-rsg-sexassignedab-definitions.html#/html/body/div/div/div/div/div/div/div/table/tr/td/a at Line 679, column 3928: The link 'Availability.html' for "Availability" cannot be resolved
+ERROR: c:\work\git\au-fhir-core\output\StructureDefinition-au-core-rsg-sexassignedab-definitions.html#/html/body/div/div/div/div/div/div/div/table/tr/td/a at Line 679, column 3974: The link 'ExtendedContactDetail.html' for "ExtendedContactDetail" cannot be resolved
+

--- a/input/ignoreWarnings.txt
+++ b/input/ignoreWarnings.txt
@@ -5,3 +5,11 @@ The HTML fragment 'ip-statements.xhtml' is not included anywhere in the produced
 An HTML fragment from the set [cross-version-analysis.xhtml, cross-version-analysis-inline.xhtml] is not included anywhere in the produced implementation guide
 An HTML fragment from the set [dependency-table.xhtml, dependency-table-short.xhtml] is not included anywhere in the produced implementation guide
 The HTML fragment 'globals-table.xhtml' is not included anywhere in the produced implementation guide
+
+# ================================================================================
+# ===  ERRORS ===
+# ===========================================================-=====================
+
+# ===  These errors are pending an update to the IG publisher for resolution; currently, there is no timeline for their correction. They are related by R4 and R5 value sets having different values, but using an R4 values returns the same error. See https://chat.fhir.org/#narrow/stream/179252-IG-creation/topic/QA.20error.20with.20ActorDefinition.20in.20R4.20IG ====
+ERROR: ActorDefinition/au-core-actor-requester: ActorDefinition.type: The value provided ('system') was not found in the value set 'Example Scenario Actor Type' (http://hl7.org/fhir/ValueSet/examplescenario-actor-type|5.0.0), and a code is required from this value set  (error message = The System URI could not be determined for the code 'system' in the ValueSet 'http://hl7.org/fhir/ValueSet/examplescenario-actor-type|5.0.0'; The provided code '#system' was not found in the value set 'http://hl7.org/fhir/ValueSet/examplescenario-actor-type|5.0.0')
+ERROR: ActorDefinition/au-core-actor-responder: ActorDefinition.type: The value provided ('system') was not found in the value set 'Example Scenario Actor Type' (http://hl7.org/fhir/ValueSet/examplescenario-actor-type|5.0.0), and a code is required from this value set  (error message = The System URI could not be determined for the code 'system' in the ValueSet 'http://hl7.org/fhir/ValueSet/examplescenario-actor-type|5.0.0'; The provided code '#system' was not found in the value set 'http://hl7.org/fhir/ValueSet/examplescenario-actor-type|5.0.0')

--- a/input/includes/link-list.md
+++ b/input/includes/link-list.md
@@ -273,7 +273,7 @@
 [clinical safety]:  {{site.data.fhir.path}}safety.html
 [Mandatory]: must-support.html
 [Using multiple codes with CodeableConcept Datatype]: general-requirements.html#translations
-[Maturity Level]: {{site.data.fhir.path}}versions.html#maturity
+[Maturity Level]: https://build.fhir.org/ig/hl7au/au-fhir-base/guidance.html#maturity-levels
 [slicing]: {{site.data.fhir.path}}profiling.html#slicing
 [Change Log]: changes.html
 [Deletion Safety Checks]: http://hl7.org/fhir/R4/safety.html#conformance

--- a/input/pagecontent/changes.md
+++ b/input/pagecontent/changes.md
@@ -142,7 +142,7 @@ This change log documents the significant updates and resolutions implemented fr
     - removed the required binding to ObservationStatus Result Available value set from Observation.status [FHIR-45125](https://jira.hl7.org/browse/FHIR-45125)
 - Made the following changes in AU Core Requester CapabilityStatement:
   - removed reference to Bulk Data Access implementation guide [FHIR-45113](https://jira.hl7.org/browse/FHIR-45113)
-  - corrected the combined search parameter 'patient+category+status' from SHALL to SHOULD [FHIR-45390](https://jira.hl7.org/browse/FHIR-45390)
+  - corrected the Observation combined search parameter 'patient+category+status' from SHALL to SHOULD [FHIR-45390](https://jira.hl7.org/browse/FHIR-45390)
 - Made the following changes in AU Core Responder CapabilityStatement:
   - removed reference to Bulk Data Access implementation guide [FHIR-45113](https://jira.hl7.org/browse/FHIR-45113)
-  - corrected the combined search parameter 'patient+category+status' from SHALL to SHOULD [FHIR-45390](https://jira.hl7.org/browse/FHIR-45390)
+  - corrected the Observation combined search parameter 'patient+category+status' from SHALL to SHOULD [FHIR-45390](https://jira.hl7.org/browse/FHIR-45390)

--- a/input/pagecontent/changes.md
+++ b/input/pagecontent/changes.md
@@ -142,5 +142,7 @@ This change log documents the significant updates and resolutions implemented fr
     - removed the required binding to ObservationStatus Result Available value set from Observation.status [FHIR-45125](https://jira.hl7.org/browse/FHIR-45125)
 - Made the following changes in AU Core Requester CapabilityStatement:
   - removed reference to Bulk Data Access implementation guide [FHIR-45113](https://jira.hl7.org/browse/FHIR-45113)
+  - corrected the combined search parameter 'patient+category+status' from SHALL to SHOULD [FHIR-45390](https://jira.hl7.org/browse/FHIR-45390)
 - Made the following changes in AU Core Responder CapabilityStatement:
   - removed reference to Bulk Data Access implementation guide [FHIR-45113](https://jira.hl7.org/browse/FHIR-45113)
+  - corrected the combined search parameter 'patient+category+status' from SHALL to SHOULD [FHIR-45390](https://jira.hl7.org/browse/FHIR-45390)

--- a/input/resources/au-core-requester.xml
+++ b/input/resources/au-core-requester.xml
@@ -3782,7 +3782,7 @@
 </extension>
 <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination">
 <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
-<valueCode value="SHALL"/>
+<valueCode value="SHOULD"/>
 </extension>
 <extension url="required">
 <valueString value="patient"/>

--- a/input/resources/au-core-responder.xml
+++ b/input/resources/au-core-responder.xml
@@ -3797,7 +3797,7 @@
 </extension>
 <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination">
 <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
-<valueCode value="SHALL"/>
+<valueCode value="SHOULD"/>
 </extension>
 <extension url="required">
 <valueString value="patient"/>


### PR DESCRIPTION
This PR addresses the following technical corrections: 
- https://jira.hl7.org/browse/FHIR-46035
  - included dependency to current versions of IPA & Smart App Launch. The version will need to be fixed to a specific version in a publication. Noting there is a qa warning about multiple different potential matches for Smart App Launch (2.2.0 & 2.0.0) due to the IG declaring dependency on the latest and the dependency on the 2.0.0 coming through the IPA.  
- https://jira.hl7.org/browse/FHIR-45390
- and other changes
  - removed dependency on the extension pack 5.1.0-snapshot
  - annotated errors confirmed to be caused by tooling
- fix for https://jira.hl7.org/browse/FHIR-46032 