### PR TITLE
AU Core Waist Circumference - remove required binding to metric units and allow the standard FHIR binding that supports metric and imperial (FHIR-44787)

### DIFF
--- a/input/pagecontent/changes.md
+++ b/input/pagecontent/changes.md
@@ -130,6 +130,7 @@ This change log documents the significant updates and resolutions implemented fr
   - removed Must Support from Observation.encounter [FHIR-45134](https://jira.hl7.org/browse/FHIR-45134)
   - removed Must Support from Observation.performer [FHIR-44786](https://jira.hl7.org/browse/FHIR-44786)  
   - removed the fixed value constraint 'final' on Observation.status [FHIR-45120](https://jira.hl7.org/browse/FHIR-45120)
+  - removed the required binding to Metric Body Length Units value set from Observation.valueQuantity.code to allow the FHIR standard profile binding, and added the Metric Body Length Units value set as a candidate additional binding [FHIR-44787](https://jira.hl7.org/browse/FHIR-44787)
 - Corrected the search parameter for gender identity to be `gender-identity` not `patient-gender-identity` [FHIR-45057](https://jira.hl7.org/browse/FHIR-45057).
 - Changed the following Organization search parameters:
   - address search parameter to be SHOULD instead of SHALL [FHIR-45133](https://jira.hl7.org/browse/FHIR-45133)

--- a/input/resources/au-core-waistcircum.xml
+++ b/input/resources/au-core-waistcircum.xml
@@ -321,10 +321,21 @@
       <type> 
         <code value="code"/> 
       </type> 
-      <binding> 
-        <strength value="required"/> 
-        <valueSet value="https://healthterminologies.gov.au/fhir/ValueSet/metric-body-length-units-1"/> 
-      </binding> 
+      <binding>
+        <extension url="http://hl7.org/fhir/tools/StructureDefinition/additional-binding">
+          <extension url="purpose">
+            <valueCode value="candidate"/>
+          </extension>
+          <extension url="valueSet">
+            <valueCanonical value="https://healthterminologies.gov.au/fhir/ValueSet/metric-body-length-units-1"/>
+          </extension>
+          <extension url="documentation">
+            <valueMarkdown value="For when metric units are preferred."/>
+          </extension>          
+        </extension>
+        <strength value="required"/>
+        <valueSet value="http://hl7.org/fhir/ValueSet/ucum-bodylength"/>
+      </binding>
     </element> 
     <element id="Observation.dataAbsentReason">
       <extension url="http://hl7.org/fhir/StructureDefinition/obligation">


### PR DESCRIPTION
This PR addresses changes for AU Core Waist Circumference, as part of https://jira.hl7.org/browse/FHIR-44787.