### PR TITLE
Fixes for FHIR-46108, FHIR-46160 & FHIR-46159: FMM=1 & status=active

### DIFF
--- a/input/ig.xml
+++ b/input/ig.xml
@@ -5,13 +5,13 @@
 		<valueCode value="draft"/>
 	</extension>
 	<extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
-		<valueInteger value="0"/>
+		<valueInteger value="1"/>
 	</extension>
 	<url value="http://hl7.org.au/fhir/core/ImplementationGuide/hl7.fhir.au.core"/>
 	<version value="0.4.0-ci-build"/>
 	<name value="AUCoreImplementationGuide"/>
 	<title value="AU Core Implementation Guide"/>
-	<status value="draft"/>
+	<status value="active"/>
 	<publisher value="HL7 Australia"/>
 	<contact>
 		<name value="HL7 Australia FHIR Work Group"/>

--- a/input/resources/au-core-actor-requester.xml
+++ b/input/resources/au-core-actor-requester.xml
@@ -1,10 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ActorDefinition xmlns="http://hl7.org/fhir">
   <id value="au-core-actor-requester"/>
+  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
+    <valueInteger value="1"/> 
+  </extension>
   <url value="http://hl7.org.au/fhir/core/ActorDefinition/au-core-actor-requester" />
   <name value="AUCoreRequester"/> 
   <title value="AU Core Requester"/> 
-  <status value="draft"/>
+  <status value="active"/>
   <description value="The AU Core Requester is a system that creates and initiates a data access request to retrieve core digital health and administrative information."/> 
   <type value="system"/> 
   <documentation value="An AU Core Client, also known as AU Core Requester:&#xa;&#xa;

--- a/input/resources/au-core-actor-responder.xml
+++ b/input/resources/au-core-actor-responder.xml
@@ -1,10 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ActorDefinition xmlns="http://hl7.org/fhir">
   <id value="au-core-actor-responder"/>
+  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
+    <valueInteger value="1"/> 
+  </extension>
   <url value="http://hl7.org.au/fhir/core/ActorDefinition/au-core-actor-responder" />
   <name value="AUCoreResponder"/> 
   <title value="AU Core Responder"/> 
-  <status value="draft"/>
+  <status value="active"/>
   <description value="The AU Core Responder is a system responsible for providing responses to queries submitted by AU Core Requesters."/> 
   <type value="system"/> 
   <documentation value="An AU Core Responder, also known as AU Core Server:&#xa;&#xa;

--- a/input/resources/au-core-allergyintolerance.xml
+++ b/input/resources/au-core-allergyintolerance.xml
@@ -1,10 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="au-core-allergyintolerance"/>
+  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
+    <valueInteger value="1"/> 
+  </extension>
   <url value="http://hl7.org.au/fhir/core/StructureDefinition/au-core-allergyintolerance"/>
   <name value="AUCoreAllergyIntolerance"/>
   <title value="AU Core AllergyIntolerance"/>
-  <status value="draft"/>
+  <status value="active"/>
   <description value="This profile sets minimum expectations for an AllergyIntolerance resource to record, search, and fetch allergies/adverse reactions associated with a patient. It is based on the [AU Base Allergy Intolerance](http://build.fhir.org/ig/hl7au/au-fhir-base/StructureDefinition-au-allergyintolerance.html) profile and identifies the *additional* mandatory core elements, extensions, vocabularies and value sets that **SHALL** be present in the AllergyIntolerance resource when conforming to this profile. It provides the floor for standards development for specific uses cases in an Australian context."/>
   <kind value="resource"/>
   <abstract value="false"/>

--- a/input/resources/au-core-bloodpressure.xml
+++ b/input/resources/au-core-bloodpressure.xml
@@ -1,10 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="au-core-bloodpressure" />
+  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
+    <valueInteger value="1"/> 
+  </extension>
   <url value="http://hl7.org.au/fhir/core/StructureDefinition/au-core-bloodpressure" />
   <name value="AUCoreBloodPressure" />
   <title value="AU Core Blood Pressure" />
-  <status value="draft" />
+  <status value="active" />
   <description value="This profile sets minimum expectations for an Observation resource to record, search, and fetch blood pressure observations with standard coding and units of measure. It is based on the [FHIR Blood Pressure Profile](http://hl7.org/fhir/R4/bp.html) and identifies the *additional* mandatory core elements, extensions, vocabularies and value sets that **SHALL** be present in the Observation resource when conforming to this profile. It provides the floor for standards development for specific uses cases in an Australian context." />
   <kind value="resource" />
   <abstract value="false" />

--- a/input/resources/au-core-bodyheight.xml
+++ b/input/resources/au-core-bodyheight.xml
@@ -1,10 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="au-core-bodyheight" />
+  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
+    <valueInteger value="1"/> 
+  </extension>
   <url value="http://hl7.org.au/fhir/core/StructureDefinition/au-core-bodyheight" />
   <name value="AUCoreBodyHeight" />
   <title value="AU Core Body Height" />
-  <status value="draft" />
+  <status value="active" />
   <description value="This profile sets minimum expectations for an Observation resource to record, search, and fetch body height observations with standard coding and units of measure. It is based on the [FHIR Body Height Profile](http://hl7.org/fhir/R4/bodyheight.html) and identifies the *additional* mandatory core elements, extensions, vocabularies and value sets that **SHALL** be present in the Observation resource when conforming to this profile. It provides the floor for standards development for specific uses cases in an Australian context." />
   <kind value="resource" />
   <abstract value="false" />

--- a/input/resources/au-core-bodytemp.xml
+++ b/input/resources/au-core-bodytemp.xml
@@ -1,10 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="au-core-bodytemp"/>
+  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
+    <valueInteger value="1"/> 
+  </extension>
   <url value="http://hl7.org.au/fhir/core/StructureDefinition/au-core-bodytemp" />
   <name value="AUCoreBodyTemperature" />
   <title value="AU Core Body Temperature" />
-  <status value="draft" />
+  <status value="active" />
   <description value="This profile sets minimum expectations for an Observation resource to record, search, and fetch body temperature observations with standard coding and units of measure. It is based on the [FHIR Body Temperature Profile](http://hl7.org/fhir/R4/bodytemp.html) and identifies the *additional* mandatory core elements, extensions, vocabularies and value sets that **SHALL** be present in the Observation resource when conforming to this profile. It provides the floor for standards development for specific uses cases in an Australian context." />
   <kind value="resource" />
   <abstract value="false" />

--- a/input/resources/au-core-bodyweight.xml
+++ b/input/resources/au-core-bodyweight.xml
@@ -1,10 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="au-core-bodyweight" />
+  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
+    <valueInteger value="1"/> 
+  </extension>
   <url value="http://hl7.org.au/fhir/core/StructureDefinition/au-core-bodyweight" />
   <name value="AUCoreBodyWeight" />
   <title value="AU Core Body Weight" />
-  <status value="draft" />
+  <status value="active" />
   <description value="This profile sets minimum expectations for an Observation resource to record, search, and fetch body weight observations with standard coding and units of measure. It is based on the [FHIR Body Weight Profile](http://hl7.org/fhir/R4/bodyweight.html) and identifies the *additional* mandatory core elements, extensions, vocabularies and value sets that **SHALL** be present in the Observation resource when conforming to this profile. It provides the floor for standards development for specific uses cases in an Australian context." />
   <kind value="resource" />
   <abstract value="false" />

--- a/input/resources/au-core-condition.xml
+++ b/input/resources/au-core-condition.xml
@@ -1,10 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="au-core-condition"/>
+  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
+    <valueInteger value="1"/> 
+  </extension>
   <url value="http://hl7.org.au/fhir/core/StructureDefinition/au-core-condition"/>
   <name value="AUCoreCondition"/>
   <title value="AU Core Condition"/>
-  <status value="draft"/>
+  <status value="active"/>
   <description value="This profile sets minimum expectations for a Condition resource to record, search, and fetch problems, diagnoses, and health concerns associated with a patient. It is based on the [AU Base Condition](http://build.fhir.org/ig/hl7au/au-fhir-base/StructureDefinition-au-condition.html) profile and identifies the *additional* mandatory core elements, extensions, vocabularies and value sets that **SHALL** be present in the Condition resource when conforming to this profile. It provides the floor for standards development for specific uses cases in an Australian context." />
   <kind value="resource"/>
   <abstract value="false"/>

--- a/input/resources/au-core-diagnosticresult-path.xml
+++ b/input/resources/au-core-diagnosticresult-path.xml
@@ -1,10 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="au-core-diagnosticresult-path"/>
+  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
+    <valueInteger value="1"/> 
+  </extension>
   <url value="http://hl7.org.au/fhir/core/StructureDefinition/au-core-diagnosticresult-path"/>
   <name value="AUCorePathologyResult"/>
   <title value="AU Core Pathology Result Observation"/>
-  <status value="draft"/>
+  <status value="active"/>
   <description value="This profile sets minimum expectations for an Observation resource to record, search, and fetch pathology results associated with a patient. It is based on the [AU Base Pathology Result](http://build.fhir.org/ig/hl7au/au-fhir-base/StructureDefinition-au-pathologyresult.html) profile and identifies the *additional* mandatory core elements, extensions, vocabularies and value sets that **SHALL** be present in the Observation when conforming to this profile. It provides the floor for standards development for specific uses cases in an Australian context." />
   <kind value="resource"/>
   <abstract value="false"/>

--- a/input/resources/au-core-diagnosticresult.xml
+++ b/input/resources/au-core-diagnosticresult.xml
@@ -1,10 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="au-core-diagnosticresult"/>
+  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
+    <valueInteger value="1"/> 
+  </extension>
   <url value="http://hl7.org.au/fhir/core/StructureDefinition/au-core-diagnosticresult"/>
   <name value="AUCoreDiagnosticResult"/>
   <title value="AU Core Diagnostic Result Observation"/>
-  <status value="draft"/>
+  <status value="active"/>
   <description value="This profile sets minimum expectations for an Observation resource to record, search, and fetch diagnostic results associated with a patient. It is based on the [AU Base Diagnostic Result](http://build.fhir.org/ig/hl7au/au-fhir-base/StructureDefinition-au-diagnosticresult.html) profile and identifies the *additional* mandatory core elements, extensions, vocabularies and value sets that **SHALL** be present in the Observation when conforming to this profile. It provides the floor for standards development for specific uses cases in an Australian context." />
   <kind value="resource"/>
   <abstract value="false"/>

--- a/input/resources/au-core-encounter.xml
+++ b/input/resources/au-core-encounter.xml
@@ -1,10 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="au-core-encounter"/>
+  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
+    <valueInteger value="1"/> 
+  </extension>
   <url value="http://hl7.org.au/fhir/core/StructureDefinition/au-core-encounter"/>
   <name value="AUCoreEncounter"/>
   <title value="AU Core Encounter"/>
-  <status value="draft"/>
+  <status value="active"/>
   <description value="This profile sets minimum expectations for an Encounter resource to record, search, and fetch basic encounter information for a patient. It is based on the [AU Base Encounter](http://build.fhir.org/ig/hl7au/au-fhir-base/StructureDefinition-au-encounter.html) profile and identifies the *additional* mandatory core elements, extensions, vocabularies and value sets that **SHALL** be present in the Encounter when conforming to this profile. It provides the floor for standards development for specific uses cases in an Australian context." />
   <kind value="resource"/>
   <abstract value="false"/>

--- a/input/resources/au-core-heartrate.xml
+++ b/input/resources/au-core-heartrate.xml
@@ -1,10 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="au-core-heartrate"/>
+  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
+    <valueInteger value="1"/> 
+  </extension>
   <url value="http://hl7.org.au/fhir/core/StructureDefinition/au-core-heartrate" />
   <name value="AUCoreHeartRate" />
   <title value="AU Core Heart Rate" />
-  <status value="draft" />
+  <status value="active" />
   <description value="This profile sets minimum expectations for an Observation resource to record, search, and fetch heart rate observations with standard coding and units of measure. It is based on the [FHIR Heart Rate Profile](http://hl7.org/fhir/R4/heartrate.html) and identifies the *additional* mandatory core elements, extensions, vocabularies and value sets that **SHALL** be present in the Observation resource when conforming to this profile. It provides the floor for standards development for specific uses cases in an Australian context." />
   <kind value="resource" />
   <abstract value="false" />

--- a/input/resources/au-core-immunization.xml
+++ b/input/resources/au-core-immunization.xml
@@ -1,10 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="au-core-immunization"/>
+  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
+    <valueInteger value="1"/> 
+  </extension>
   <url value="http://hl7.org.au/fhir/core/StructureDefinition/au-core-immunization"/>
   <name value="AUCoreImmunization"/>
   <title value="AU Core Immunization"/>
-  <status value="draft"/>
+  <status value="active"/>
   <description value="This profile sets minimum expectations for an Immunization resource to record, search, and fetch immunisation history associated with a patient. It is based on the [AU Base Immunisation](http://build.fhir.org/ig/hl7au/au-fhir-base/StructureDefinition-au-immunization.html) profile and identifies the *additional* mandatory core elements, extensions, vocabularies and value sets that **SHALL** be present in the Immunization resource when conforming to this profile. It provides the floor for standards development for specific uses cases in an Australian context." />
   <kind value="resource"/>
   <abstract value="false"/>

--- a/input/resources/au-core-location.xml
+++ b/input/resources/au-core-location.xml
@@ -1,10 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="au-core-location"/>
+  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
+    <valueInteger value="1"/> 
+  </extension>
   <url value="http://hl7.org.au/fhir/core/StructureDefinition/au-core-location"/>
   <name value="AUCoreLocation"/>
   <title value="AU Core Location"/>
-  <status value="draft" />
+  <status value="active" />
   <description value="This profile sets minimum expectations for a Location resource to record, search, and fetch information about a location. It is based on the [AU Base Location](http://build.fhir.org/ig/hl7au/au-fhir-base/StructureDefinition-au-location.html) profile and identifies the *additional* mandatory core elements, extensions, vocabularies and value sets that **SHALL** be present in the Location when conforming to this profile. It provides the floor for standards development for specific uses cases in an Australian context." />
   <kind value="resource" />
   <abstract value="false" />

--- a/input/resources/au-core-medication.xml
+++ b/input/resources/au-core-medication.xml
@@ -1,10 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="au-core-medication"/>
+  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
+    <valueInteger value="1"/> 
+  </extension>
   <url value="http://hl7.org.au/fhir/core/StructureDefinition/au-core-medication"/>
   <name value="AUCoreMedication"/>
   <title value="AU Core Medication"/>
-  <status value="draft"/>
+  <status value="active"/>
   <description value="This profile sets minimum expectations for a Medication resource to record, search, and fetch medications associated with a patient. It is based on the [AU Base Medication](http://build.fhir.org/ig/hl7au/au-fhir-base/StructureDefinition-au-medication.html) profile and identifies the *additional* mandatory core elements, extensions, vocabularies and value sets that **SHALL** be present in the Medication when conforming to this profile. It provides the floor for standards development for specific uses cases in an Australian context. &#xa;&#xa;In AU Core a Medication resource is used within the context of a referencing resource: MedicationAdministration, MedicationDispense, MedicationRequest, or MedicationStatement resource."/>
   <kind value="resource"/>
   <abstract value="false"/>

--- a/input/resources/au-core-medicationrequest.xml
+++ b/input/resources/au-core-medicationrequest.xml
@@ -1,10 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="au-core-medicationrequest"/>
+  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
+    <valueInteger value="1"/> 
+  </extension>
   <url value="http://hl7.org.au/fhir/core/StructureDefinition/au-core-medicationrequest"/>
   <name value="AUCoreMedicationRequest"/>
   <title value="AU Core MedicationRequest"/>
-  <status value="draft"/>
+  <status value="active"/>
   <description value="This profile sets minimum expectations for a MedicationRequest resource to record, search, and fetch medication orders and requests (i.e. prescriptions) associated with a patient. It is based on the [AU Base Medication Request](http://build.fhir.org/ig/hl7au/au-fhir-base/StructureDefinition-au-medicationrequest.html) profile and identifies the *additional* mandatory core elements, extensions, vocabularies and value sets that **SHALL** be present in the MedicationRequest when conforming to this profile. It provides the floor for standards development for specific uses cases in an Australian context." />
   <kind value="resource"/>
   <abstract value="false"/>

--- a/input/resources/au-core-organization.xml
+++ b/input/resources/au-core-organization.xml
@@ -1,10 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="au-core-organization"/>
+  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
+    <valueInteger value="1"/> 
+  </extension>
   <url value="http://hl7.org.au/fhir/core/StructureDefinition/au-core-organization"/>
   <name value="AUCoreOrganization"/>
   <title value="AU Core Organization"/>
-  <status value="draft"/>
+  <status value="active"/>
   <description value="This profile sets minimum expectations for a Organization resource to record, search, and fetch information about an organisation. It is based on the [AU Base Organization](http://build.fhir.org/ig/hl7au/au-fhir-base/StructureDefinition-au-organization.html) profile and identifies the *additional* mandatory core elements, extensions, vocabularies and value sets that **SHALL** be present in the Organization when conforming to this profile. It provides the floor for standards development for specific uses cases in an Australian context."/>
   <kind value="resource"/>
   <abstract value="false"/>

--- a/input/resources/au-core-patient.xml
+++ b/input/resources/au-core-patient.xml
@@ -1,10 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="au-core-patient"/>
+  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
+    <valueInteger value="1"/> 
+  </extension>
   <url value="http://hl7.org.au/fhir/core/StructureDefinition/au-core-patient"/>
   <name value="AUCorePatient"/>
   <title value="AU Core Patient"/>
-  <status value="draft"/>
+  <status value="active"/>
   <description value="This profile sets minimum expectations for a Patient resource to record, search, and fetch basic demographics and other administrative information about an individual patient. It is based on the [AU Base Patient](http://build.fhir.org/ig/hl7au/au-fhir-base/StructureDefinition-au-patient.html) profile and identifies the *additional* mandatory core elements, extensions, vocabularies and value sets that **SHALL** be present in the Patient when conforming to this profile. It provides the floor for standards development for specific uses cases in an Australian context."/>
   <kind value="resource"/>
   <abstract value="false"/>

--- a/input/resources/au-core-practitioner.xml
+++ b/input/resources/au-core-practitioner.xml
@@ -1,10 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="au-core-practitioner"/>
+  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
+    <valueInteger value="1"/> 
+  </extension>
   <url value="http://hl7.org.au/fhir/core/StructureDefinition/au-core-practitioner"/>
   <name value="AUCorePractitioner"/>
   <title value="AU Core Practitioner"/>
-  <status value="draft"/>
+  <status value="active"/>
   <description value="This profile sets minimum expectations for a Practitioner resource to record, search, and fetch basic demographics and other administrative information about an individual practitioner. It is based on the [AU Base Practitioner](http://build.fhir.org/ig/hl7au/au-fhir-base/StructureDefinition-au-practitioner.html) profile and identifies the *additional* mandatory core elements, extensions, vocabularies and value sets that **SHALL** be present in the Practitioner when conforming to this profile. It provides the floor for standards development for specific uses cases in an Australian context."/>
   <kind value="resource"/>
   <abstract value="false"/>

--- a/input/resources/au-core-practitionerrole.xml
+++ b/input/resources/au-core-practitionerrole.xml
@@ -1,10 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="au-core-practitionerrole"/>
+  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
+    <valueInteger value="1"/> 
+  </extension>
   <url value="http://hl7.org.au/fhir/core/StructureDefinition/au-core-practitionerrole"/>
   <name value="AUCorePractitionerRole"/>
   <title value="AU Core PractitionerRole"/>
-  <status value="draft"/>
+  <status value="active"/>
   <description value="This profile sets minimum expectations for a PractitionerRole resource to record, search, and fetch a practitioner role for a practitioner associated with a patient. It is based on the [AU Base Practitioner Role](http://build.fhir.org/ig/hl7au/au-fhir-base/StructureDefinition-au-practitionerrole.html) profile and identifies the *additional* mandatory core elements, extensions, vocabularies and value sets that **SHALL** be present in the PractitionerRole resource when conforming to this profile. It provides the floor for standards development for specific uses cases in an Australian context."/>
   <kind value="resource"/>
   <abstract value="false"/>

--- a/input/resources/au-core-procedure.xml
+++ b/input/resources/au-core-procedure.xml
@@ -3,7 +3,7 @@
   <url value="http://hl7.org.au/fhir/core/StructureDefinition/au-core-procedure"/>
   <name value="AUCoreProcedure"/>
   <title value="AU Core Procedure"/>
-  <status value="draft"/>
+  <status value="active"/>
   <description value="This profile sets minimum expectations for a Procedure resource to record, search, and fetch procedures associated with a patient. It is based on the [AU Base Procedure](http://build.fhir.org/ig/hl7au/au-fhir-base/StructureDefinition-au-procedure.html) profile and identifies the *additional* mandatory core elements, extensions, vocabularies and value sets that **SHALL** be present in the Procedure resource when conforming to this profile. It provides the floor for standards development for specific uses cases in an Australian context." />
   <kind value="resource"/>
   <abstract value="false"/>

--- a/input/resources/au-core-requester.xml
+++ b/input/resources/au-core-requester.xml
@@ -1,7 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CapabilityStatement xmlns="http://hl7.org/fhir">
   <id value="au-core-requester"/>
-<text>
+  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
+    <valueInteger value="1"/> 
+  </extension>
+  <text>
     <status value="extensions"/>
     <div xmlns="http://www.w3.org/1999/xhtml">
       <h2 id="title">AU Core Requester CapabilityStatement</h2>
@@ -2832,7 +2835,7 @@
 <url value="http://hl7.org.au/fhir/core/CapabilityStatement/au-core-requester"/>
 <name value="AUCoreRequesterCapabilityStatement"/>
 <title value="AU Core Requester CapabilityStatement"/>
-<status value="draft"/>
+<status value="active"/>
 <date value="2023-05-15"/>
 <description value="This CapabilityStatement describes the basic rules for the [AU Core Requester actor](ActorDefinition-au-core-actor-requester.html) is responsible for creating and initiating the queries for information. The complete list of FHIR profiles, RESTful operations, and search parameters supported by AU Core Requesters are defined in this CapabilityStatement."/>
 <kind value="requirements"/>

--- a/input/resources/au-core-responder.xml
+++ b/input/resources/au-core-responder.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CapabilityStatement xmlns="http://hl7.org/fhir">
   <id value="au-core-responder"/>
+  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
+    <valueInteger value="1"/> 
+  </extension>
   <text>
     <status value="extensions"/>
     <div xmlns="http://www.w3.org/1999/xhtml">
@@ -2854,7 +2857,7 @@
 <url value="http://hl7.org.au/fhir/core/CapabilityStatement/au-core-responder"/>
 <name value="AUCoreResponderCapabilityStatement"/>
 <title value="AU Core Responder CapabilityStatement"/>
-<status value="draft"/>
+<status value="active"/>
 <date value="2023-05-15"/>
 <description value="This CapabilityStatement describes the basic rules for the [AU Core Responder actor](ActorDefinition-au-core-actor-responder.html) that is responsible for providing responses to queries submitted by AU Core Requesters. The complete list of FHIR profiles, RESTful operations, and search parameters supported by AU Core Responders are defined in this CapabilityStatement."/>
 <kind value="requirements"/>

--- a/input/resources/au-core-resprate.xml
+++ b/input/resources/au-core-resprate.xml
@@ -1,10 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="au-core-resprate"/>
+  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
+    <valueInteger value="1"/> 
+  </extension>
   <url value="http://hl7.org.au/fhir/core/StructureDefinition/au-core-resprate" />
   <name value="AUCoreRespirationRate" />
   <title value="AU Core Respiration Rate" />
-  <status value="draft" />
+  <status value="active" />
   <description value="This profile sets minimum expectations for an Observation resource to record, search, and fetch respiration rate observations with standard coding and units of measure. It is based on the [FHIR Respiratory Rate Profile](http://hl7.org/fhir/R4/resprate.html) and identifies the *additional* mandatory core elements, extensions, vocabularies and value sets that **SHALL** be present in the Observation resource when conforming to this profile. It provides the floor for standards development for specific uses cases in an Australian context." />
   <kind value="resource" />
   <abstract value="false" />

--- a/input/resources/au-core-rsg-sexassignedab.xml
+++ b/input/resources/au-core-rsg-sexassignedab.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="au-core-rsg-sexassignedab"/>
+  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
+		<valueInteger value="0"/>
+	</extension>
   <url value="http://hl7.org.au/fhir/core/StructureDefinition/au-core-rsg-sexassignedab"/>
   <name value="AUCoreSexAssignedAtBirth"/>
   <title value="AU Core Sex Assigned At Birth"/>

--- a/input/resources/au-core-smokingstatus.xml
+++ b/input/resources/au-core-smokingstatus.xml
@@ -1,10 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="au-core-smokingstatus" />
+  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
+        <valueInteger value="1"/> 
+  </extension>
   <url value="http://hl7.org.au/fhir/core/StructureDefinition/au-core-smokingstatus" />
   <name value="AUCoreSmokingStatus" />
   <title value="AU Core Smoking Status" />
-  <status value="draft" />
+  <status value="active" />
   <description value="This profile sets minimum expectations for an Observation resource to record, search, and fetch observations that represent a patient’s smoking status, i.e. current behaviour for all types of tobacco smoking, with standard coding. It is based on the core FHIR [Observation](http://hl7.org/fhir/R4/observation.html) resource and identifies the *additional* mandatory core elements, extensions, vocabularies and value sets that **SHALL** be present in the Observation resource when conforming to this profile. It provides the floor for standards development for specific uses cases in an Australian context." />
   <kind value="resource" />
   <abstract value="false" />

--- a/input/resources/au-core-waistcircum.xml
+++ b/input/resources/au-core-waistcircum.xml
@@ -1,10 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="au-core-waistcircum"/>
+  <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
+        <valueInteger value="1"/> 
+  </extension>
   <url value="http://hl7.org.au/fhir/core/StructureDefinition/au-core-waistcircum" />
   <name value="AUCoreWaistCircumference" />
   <title value="AU Core Waist Circumference" />
-  <status value="draft" />
+  <status value="active" />
   <description value="This profile sets minimum expectations for an Observation resource to record, search, and fetch waist circumference observations with standard coding and units of measure. It is based on the [FHIR Vital Signs Profile](http://hl7.org/fhir/R4/vitalsigns.html) and identifies the *additional* mandatory core elements, extensions, vocabularies and value sets that **SHALL** be present in the Observation resource when conforming to this profile. It provides the floor for standards development for specific uses cases in an Australian context." />
   <kind value="resource" />
   <abstract value="false" />

--- a/input/resources/searchparameter-au-core-clinical-patient.xml
+++ b/input/resources/searchparameter-au-core-clinical-patient.xml
@@ -1,10 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SearchParameter xmlns="http://hl7.org/fhir">
     <id value="au-core-clinical-patient"/>
+    <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
+        <valueInteger value="1"/> 
+    </extension>
     <url value="http://hl7.org.au/fhir/core/SearchParameter/au-core-clinical-patient"/>
     <name value="AUCoreClinicalPatient"/>
     <derivedFrom value="http://hl7.org/fhir/SearchParameter/clinical-patient"/>
-    <status value="draft"/>
+    <status value="active"/>
     <description value="A clinical patient **SHOULD** support patient.identifier. This AU Core SearchParameter extends the usage context of the&#xA;clinical-patient parameter&#xA; - multipleAnd&#xA; - multipleOr&#xA; - chain"/>
     <code value="patient"/>
     <base value="AllergyIntolerance"/>

--- a/input/resources/searchparameter-au-core-practitionerrole-practitioner.xml
+++ b/input/resources/searchparameter-au-core-practitionerrole-practitioner.xml
@@ -1,10 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SearchParameter xmlns="http://hl7.org/fhir">
     <id value="au-core-practitionerrole-practitioner"/>
+    <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
+        <valueInteger value="1"/> 
+    </extension>
     <url value="http://hl7.org.au/fhir/core/SearchParameter/au-core-practitionerrole-practitioner"/>
     <name value="AUCorePractitionerRolePractitioner"/>
     <derivedFrom value="http://hl7.org/fhir/SearchParameter/PractitionerRole-practitioner"/>
-    <status value="draft"/>
+    <status value="active"/>
     <description value="A practitioner role practitioner **SHOULD** support practitioner.identifier. NOTE: This AU Core SearchParameter extends the usage context of the&#xA;PractitionerRole-practitioner parameter&#xA; - multipleAnd&#xA; - multipleOr&#xA; - chain"/>
     <code value="practitioner"/>
     <base value="PractitionerRole"/>


### PR DESCRIPTION
Fixes for [FHIR-46108](https://jira.hl7.org/browse/FHIR-46108), [FHIR-46160](https://jira.hl7.org/browse/FHIR-46160) & [FHIR-46159](https://jira.hl7.org/browse/FHIR-46159): 

* Marked AU Core artefacts with the exclusion of AU Core Sex Assigned at Birth as FMM=1 & status=active
* Marked ig as FMM=1 & status=active (picking up underlying artefact status)
* Added FMM extension to AU Core Sex Assigned at Birth as FMMM=0

