### PR TITLE
Fix technical corrections: FHIR-46211, FHIR-46184, FHIR-46211, FHIR-46209, FHIR-46167

### DIFF
--- a/input/intro-notes/StructureDefinition-au-core-condition-notes.md
+++ b/input/intro-notes/StructureDefinition-au-core-condition-notes.md
@@ -47,6 +47,7 @@
         <td>patient+onset-date</td>
         <td><b>SHOULD</b></td>
         <td><code>reference</code>+<code>date</code></td>
+        <td></td>
   </tr>
   <tr>
         <td>category</td>
@@ -144,7 +145,7 @@ The following search parameters and search parameter combinations **SHOULD** be 
 
     *Implementation Notes:* Fetches a bundle of all Condition resources for the specified patient and condition code(s). **SHOULD** support search by multiple codes. The Condition `code` parameter searches `Condition.code` only. ([how to search by reference](http://hl7.org/fhir/R4/search.html#reference) and [how to search by token](http://hl7.org/fhir/R4/search.html#token))
 
-    1. **SHOULD** support searching using the combination of the **[`patient`](https://hl7.org/fhir/R4/condition.html#search)** and **[`onset-date`](https://hl7.org/fhir/R4/condition.html#search)** search parameters:
+1. **SHOULD** support searching using the combination of the **[`patient`](https://hl7.org/fhir/R4/condition.html#search)** and **[`onset-date`](https://hl7.org/fhir/R4/condition.html#search)** search parameters:
     - **SHOULD** support chained searching of patient canonical identifier `patient.identifier` (e.g. `patient.identifier=[system|][code]`
     - **SHALL** support these `onset-date` comparators: `gt,lt,ge,le`
     - **SHOULD** support *[multipleAnd](http://hl7.org/fhir/R4/searchparameter-definitions.html#SearchParameter.multipleAnd)* search on `onset-date` (e.g.`onset-date=[date]&date=[date]]&...`)

--- a/input/intro-notes/StructureDefinition-au-core-immunization-notes.md
+++ b/input/intro-notes/StructureDefinition-au-core-immunization-notes.md
@@ -103,16 +103,3 @@ The following search parameters and search parameter combinations **SHOULD** be 
       1. GET [base]/Immunization?patient.identifier=http://example.org/fhir/mrn\|12345&amp;date=ge2020-01-01T00:00:00Z
 
     *Implementation Notes:* Fetches a bundle of all Immunization resources for the specified patient and date ([how to search by reference](http://hl7.org/fhir/R4/search.html#reference) and [how to search by date](http://hl7.org/fhir/R4/search.html#date))
-
-1. **SHOULD** support searching using the combination of the **[`patient`](https://hl7.org/fhir/R4/immunization.html#search)** and **[`vaccine-code`](https://hl7.org/fhir/R4/immunization.html#search)** search parameters:
-    - **SHOULD** support chained searching of patient canonical identifier `patient.identifier` (e.g. `patient.identifier=[system|][code]`
-    - **SHOULD** support *[multipleOr](http://hl7.org/fhir/R4/searchparameter-definitions.html#SearchParameter.multipleOr)* search on `vaccine-code` (e.g.`vaccine-code={system|}[code],{system|}[code],...`)
-
-    `GET [base]/Immunization?patient={Type/}[id]&vaccine-code={system|}[code]{,{system|}[code],...}`
-
-    Example:
-    
-      1. GET [base]/Immunization?patient=5678&amp;vaccine-code=https://www.humanservices.gov.au/organisations/health-professionals/enablers/air-vaccine-code-formats\|COMIRN,http://snomed.info/sct\|1525011000168107
-      1. GET [base]/Immunization?patient.identifier=http://example.org/fhir/mrn\|12345&amp;vaccine-code=https://www.humanservices.gov.au/organisations/health-professionals/enablers/air-vaccine-code-formats\|COMIRN,http://snomed.info/sct\|1525011000168107
-
-    *Implementation Notes:* Fetches a bundle of all Immunization resources for the specified patient and immunization code(s). **SHOULD** support search by multiple codes. ([how to search by reference](http://hl7.org/fhir/R4/search.html#reference) and [how to search by token](http://hl7.org/fhir/R4/search.html#token))

--- a/input/intro-notes/StructureDefinition-au-core-medicationrequest-notes.md
+++ b/input/intro-notes/StructureDefinition-au-core-medicationrequest-notes.md
@@ -101,7 +101,6 @@ The following search parameters and search parameter combinations **SHALL** be s
 1. **SHALL** support searching using the combination of the **[`patient`](https://hl7.org/fhir/R4/medicationrequest.html#search)** and **[`intent`](https://hl7.org/fhir/R4/medicationrequest.html#search)** and **[`status`](https://hl7.org/fhir/R4/medicationrequest.html#search)** search parameters:
     - **SHOULD** support these **[`_include`](http://hl7.org/fhir/R4/search.html#include)** parameters: `MedicationRequest:medication`
     - **SHOULD** support chained searching of patient canonical identifier `patient.identifier` (e.g. `patient.identifier=[system|][code]`)
-    - **SHALL** support *[multipleOr](http://hl7.org/fhir/R4/searchparameter-definitions.html#SearchParameter.multipleOr)* search on `code` (e.g.`code={system|}[code],{system|}[code],...`)
     - **SHALL** support *[multipleOr](http://hl7.org/fhir/R4/searchparameter-definitions.html#SearchParameter.multipleOr)* search on `status` (e.g.`status={system|}[code],{system|}[code],...`)
 
 
@@ -112,7 +111,7 @@ The following search parameters and search parameter combinations **SHALL** be s
       1. GET [base]/MedicationRequest?patient=5678&amp;intent=order&amp;status=active
       1. GET [base]/MedicationRequest?patient=5678&amp;intent=order&amp;status=active&amp;_include=MedicationRequest:medication
 
-    *Implementation Notes:* Fetches a bundle of all MedicationRequest resources for the specified patient and authored on date and intent ([how to search by reference](http://hl7.org/fhir/R4/search.html#reference) and [how to search by token](http://hl7.org/fhir/R4/search.html#token))
+    *Implementation Notes:* Fetches a bundle of all MedicationRequest resources for the specified patient and intent and status ([how to search by reference](http://hl7.org/fhir/R4/search.html#reference) and [how to search by token](http://hl7.org/fhir/R4/search.html#token))
 
 
 #### Optional Search Parameters

--- a/input/pagecontent/changes.md
+++ b/input/pagecontent/changes.md
@@ -147,9 +147,9 @@ This change log documents the significant updates and resolutions implemented fr
 - Made the following changes in AU Core Requester CapabilityStatement:
   - removed reference to Bulk Data Access implementation guide [FHIR-45113](https://jira.hl7.org/browse/FHIR-45113)
   - corrected the Observation combined search parameter 'patient+category+status' from SHALL to SHOULD [FHIR-45390](https://jira.hl7.org/browse/FHIR-45390)
-  - corrected narrative of Location identifier parameter requester requirements on providing both the system and code values from SHOULD to MAY [FHIR-46209](https://jira.hl7.org/browse/FHIR-46167)
+  - corrected narrative of Location identifier parameter requester requirements on providing both the system and code values from SHOULD to MAY [FHIR-46209](https://jira.hl7.org/browse/FHIR-46209)
 - Made the following changes in AU Core Responder CapabilityStatement:
   - removed reference to Bulk Data Access implementation guide [FHIR-45113](https://jira.hl7.org/browse/FHIR-45113)
   - corrected the Observation combined search parameter 'patient+category+status' from SHALL to SHOULD [FHIR-45390](https://jira.hl7.org/browse/FHIR-45390)
   - corrected MedicationRequest combined search parameter 'patient+intent+authoredon' from SHALL to SHOULD [FHIR-46167](https://jira.hl7.org/browse/FHIR-46167)
-  - corrected narrative of Location identifier parameter requester requirements on providing both the system and code values from SHOULD to MAY [FHIR-46209](https://jira.hl7.org/browse/FHIR-46167)
+  - corrected narrative of Location identifier parameter requester requirements on providing both the system and code values from SHOULD to MAY [FHIR-46209](https://jira.hl7.org/browse/FHIR-46209)

--- a/input/pagecontent/changes.md
+++ b/input/pagecontent/changes.md
@@ -147,6 +147,9 @@ This change log documents the significant updates and resolutions implemented fr
 - Made the following changes in AU Core Requester CapabilityStatement:
   - removed reference to Bulk Data Access implementation guide [FHIR-45113](https://jira.hl7.org/browse/FHIR-45113)
   - corrected the Observation combined search parameter 'patient+category+status' from SHALL to SHOULD [FHIR-45390](https://jira.hl7.org/browse/FHIR-45390)
+  - corrected narrative of Location identifier parameter requester requirements on providing both the system and code values from SHOULD to MAY [FHIR-46209](https://jira.hl7.org/browse/FHIR-46167)
 - Made the following changes in AU Core Responder CapabilityStatement:
   - removed reference to Bulk Data Access implementation guide [FHIR-45113](https://jira.hl7.org/browse/FHIR-45113)
   - corrected the Observation combined search parameter 'patient+category+status' from SHALL to SHOULD [FHIR-45390](https://jira.hl7.org/browse/FHIR-45390)
+  - corrected MedicationRequest combined search parameter 'patient+intent+authoredon' from SHALL to SHOULD [FHIR-46167](https://jira.hl7.org/browse/FHIR-46167)
+  - corrected narrative of Location identifier parameter requester requirements on providing both the system and code values from SHOULD to MAY [FHIR-46209](https://jira.hl7.org/browse/FHIR-46167)

--- a/input/resources/au-core-requester.xml
+++ b/input/resources/au-core-requester.xml
@@ -1398,7 +1398,7 @@
     </td>
     <td>
       <div>
-        <p>The requester <strong>SHALL</strong> provide at least a code value and <strong>SHOULD</strong> provide both the system and code values.</p>
+        <p>The requester <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p>
         <p>The responder <strong>SHALL</strong> support both.</p>
       </div>
     </td>

--- a/input/resources/au-core-responder.xml
+++ b/input/resources/au-core-responder.xml
@@ -1416,7 +1416,7 @@
   </td>
   <td>
     <div>
-      <p>The requester <strong>SHALL</strong> provide at least a code value and <strong>SHOULD</strong> provide both the system and code values.</p>
+      <p>The requester <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p>
       <p>The responder <strong>SHALL</strong> support both.</p>
     </div>
   </td>

--- a/input/resources/au-core-responder.xml
+++ b/input/resources/au-core-responder.xml
@@ -3643,7 +3643,7 @@
 </extension>
 <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination">
 <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
-<valueCode value="SHALL"/>
+<valueCode value="SHOULD"/>
 </extension>
 <extension url="required">
 <valueString value="patient"/>


### PR DESCRIPTION
Fixes for:
[FHIR-46167](https://jira.hl7.org/browse/FHIR-46167) MedicationRequest resource combined search parameter 'patient + intent + authoredon' should be SHOULD
[FHIR-46212](https://jira.hl7.org/browse/FHIR-46212) AU Core MedicationRequest Notes: fix combined search parameter 'patient+intent' documentation
[FHIR-46184](https://jira.hl7.org/browse/FHIR-46184) Condition search by patient+onset-date formatting issues
[FHIR-46211](https://jira.hl7.org/browse/FHIR-46211) AU Core Immunization Optional Search Parameters: combined search parameter 'patient+vaccine-code' is incorrectly listed as SHOULD
[FHIR-46209](https://jira.hl7.org/browse/FHIR-46209) Update CapabilityStatements to require MAY provide both the system and code values for location identifier, instead of SHOULD