### PR TITLE
 AllergyIntolerance.Code refined subset bindings (https://jira.hl7.org/browse/FHIR-44713)

### DIFF
--- a/input/pagecontent/changes.md
+++ b/input/pagecontent/changes.md
@@ -91,7 +91,9 @@ This change log documents the significant updates and resolutions implemented fr
   - removed Must Support from AllergyIntolerance.recorder [FHIR-45082](https://jira.hl7.org/browse/FHIR-45082), [FHIR-45066](https://jira.hl7.org/browse/FHIR-45066)
   - removed Must Support from AllergyIntolerance.encounter [FHIR-45123](https://jira.hl7.org/browse/FHIR-45123)
   - removed Must Support from AllergyIntolerance.note [FHIR-45188](https://jira.hl7.org/browse/FHIR-45188)
-  - changed the AllergyIntolerance.code binding Indicator of Hypersensitivity or Intolerance to Substance to be extensible, and added Adverse Reaction Substances and Negated Findings as an Additional Binding with a purpose as candidate [FHIR-44713](https://jira.hl7.org/browse/FHIR-44713) 
+  - changed the AllergyIntolerance.code 
+    - changed Indicator of Hypersensitivity or Intolerance to Substance value set binding strength from preferred to extensible [FHIR-44713](https://jira.hl7.org/browse/FHIR-44713) 
+    - added Adverse Reaction Substances and Negated Findings value set as candidate [FHIR-44713](https://jira.hl7.org/browse/FHIR-44713) 
 - Made the following changes to AU Core Smoking Status: 
   - removed Must Support from Observation.encounter [FHIR-45222](https://jira.hl7.org/browse/FHIR-45222)
   - removed Must Support from Observation.performer [FHIR-45223](https://jira.hl7.org/browse/FHIR-45223)

--- a/input/pagecontent/changes.md
+++ b/input/pagecontent/changes.md
@@ -86,11 +86,12 @@ This change log documents the significant updates and resolutions implemented fr
   - removed Must Support from  Condition.recorder [FHIR-45019](https://jira.hl7.org/browse/FHIR-45019), [FHIR-45082](https://jira.hl7.org/browse/FHIR-45082)
   - removed Must Support from Condition.encounter [FHIR-45189](https://jira.hl7.org/browse/FHIR-45189)
   - added profile-specific implementation guidance on representing no known problems [FHIR-45058](https://jira.hl7.org/browse/FHIR-45058)
-- Removed Must Support from the following elements in AU Core AllergyIntolerance:
-  - AllergyIntolerance.asserter [FHIR-44699](https://jira.hl7.org/browse/FHIR-44699), [FHIR-45083](https://jira.hl7.org/browse/FHIR-45083)
-  - AllergyIntolerance.recorder [FHIR-45082](https://jira.hl7.org/browse/FHIR-45082), [FHIR-45066](https://jira.hl7.org/browse/FHIR-45066)
-  - AllergyIntolerance.encounter [FHIR-45123](https://jira.hl7.org/browse/FHIR-45123)
-  - AllergyIntolerance.note [FHIR-45188](https://jira.hl7.org/browse/FHIR-45188)
+- Made the following changes to AU Core AllergyIntolerance:
+  - removed Must Support from AllergyIntolerance.asserter [FHIR-44699](https://jira.hl7.org/browse/FHIR-44699), [FHIR-45083](https://jira.hl7.org/browse/FHIR-45083)
+  - removed Must Support from AllergyIntolerance.recorder [FHIR-45082](https://jira.hl7.org/browse/FHIR-45082), [FHIR-45066](https://jira.hl7.org/browse/FHIR-45066)
+  - removed Must Support from AllergyIntolerance.encounter [FHIR-45123](https://jira.hl7.org/browse/FHIR-45123)
+  - removed Must Support from AllergyIntolerance.note [FHIR-45188](https://jira.hl7.org/browse/FHIR-45188)
+  - changed the AllergyIntolerance.code binding Indicator of Hypersensitivity or Intolerance to Substance to be extensible, and added Adverse Reaction Substances and Negated Findings as an Additional Binding with a purpose as candidate [FHIR-44713](https://jira.hl7.org/browse/FHIR-44713) 
 - Made the following changes to AU Core Smoking Status: 
   - removed Must Support from Observation.encounter [FHIR-45222](https://jira.hl7.org/browse/FHIR-45222)
   - removed Must Support from Observation.performer [FHIR-45223](https://jira.hl7.org/browse/FHIR-45223)

--- a/input/pagecontent/changes.md
+++ b/input/pagecontent/changes.md
@@ -93,7 +93,7 @@ This change log documents the significant updates and resolutions implemented fr
   - removed Must Support from AllergyIntolerance.note [FHIR-45188](https://jira.hl7.org/browse/FHIR-45188)
   - changed the AllergyIntolerance.code 
     - changed Indicator of Hypersensitivity or Intolerance to Substance value set binding strength from preferred to extensible [FHIR-44713](https://jira.hl7.org/browse/FHIR-44713) 
-    - added Adverse Reaction Substances and Negated Findings value set as candidate [FHIR-44713](https://jira.hl7.org/browse/FHIR-44713) 
+    - added Additional Binding, Adverse Reaction Substances and Negated Findings value set as candidate [FHIR-44713](https://jira.hl7.org/browse/FHIR-44713) 
 - Made the following changes to AU Core Smoking Status: 
   - removed Must Support from Observation.encounter [FHIR-45222](https://jira.hl7.org/browse/FHIR-45222)
   - removed Must Support from Observation.performer [FHIR-45223](https://jira.hl7.org/browse/FHIR-45223)

--- a/input/resources/au-core-allergyintolerance.xml
+++ b/input/resources/au-core-allergyintolerance.xml
@@ -78,6 +78,21 @@
       <path value="AllergyIntolerance.code"/>
       <min value="1"/>
       <mustSupport value="true"/>
+      <binding>
+        <extension url="http://hl7.org/fhir/tools/StructureDefinition/additional-binding">
+          <extension url="purpose">
+            <valueCode value="candidate"/>
+          </extension>
+          <extension url="valueSet">
+            <valueCanonical value="https://healthterminologies.gov.au/fhir/ValueSet/adverse-reaction-substances-and-negated-findings-1"/>
+          </extension>
+          <extension url="documentation">
+            <valueMarkdown value="The Adverse Reaction Substances and Negated Findings value set comprises terms used to identify a predisposition to adverse reactions to substances, as well as negated findings."/>
+          </extension>          
+        </extension>
+        <strength value="extensible" />
+        <valueSet value="https://healthterminologies.gov.au/fhir/ValueSet/indicator-hypersensitivity-intolerance-to-substance-2"/>
+      </binding>
     </element>
     <element id="AllergyIntolerance.patient">
       <extension url="http://hl7.org/fhir/StructureDefinition/obligation">


### PR DESCRIPTION
This PR includes changes for [FHIR-44713](https://jira.hl7.org/browse/FHIR-44713): 

- Changed the AllergyIntolerance.Code binding [Indicator of Hypersensitivity or Intolerance to Substance](http://example.com/) to be extensible
- Added a new value set Adverse Reaction Substances and Negated Findings as an Additional Binding with a purpose as candidate
- Updated Change log
