### PR TITLE
fix for FHIR-46147

### DIFF
--- a/input/intro-notes/StructureDefinition-au-core-medicationrequest-notes.md
+++ b/input/intro-notes/StructureDefinition-au-core-medicationrequest-notes.md
@@ -130,7 +130,7 @@ The following search parameters and search parameter combinations **SHOULD** be 
       1. GET [base]/MedicationRequest?_id=2169591
       1. GET [base]/MedicationRequest?_id=2169591&amp;_include=MedicationRequest:medication
 
-    *Implementation Notes:* Fetches a single MedicationRequest ([how to search by the logical id](http://hl7.org/fhir/R4/references.html#logical) of the resource)
+    *Implementation Notes:* Fetches a single MedicationRequest ([how to search by id of the resource](https://hl7.org/fhir/r4/search.html#id) of the resource)
 
 1. **SHOULD** support searching using the combination of the **[`patient`](https://hl7.org/fhir/R4/medicationrequest.html#search)** and **[`intent`](https://hl7.org/fhir/R4/medicationrequest.html#search)** and **[`authoredon`](https://hl7.org/fhir/R4/medicationrequest.html#search)** search parameters:
     - **SHOULD** support these **[`_include`](http://hl7.org/fhir/R4/search.html#include)** parameters: `MedicationRequest:medication`

--- a/input/intro-notes/StructureDefinition-au-core-medicationrequest-notes.md
+++ b/input/intro-notes/StructureDefinition-au-core-medicationrequest-notes.md
@@ -130,7 +130,7 @@ The following search parameters and search parameter combinations **SHOULD** be 
       1. GET [base]/MedicationRequest?_id=2169591
       1. GET [base]/MedicationRequest?_id=2169591&amp;_include=MedicationRequest:medication
 
-    *Implementation Notes:* Fetches a single MedicationRequest ([how to search by id of the resource](https://hl7.org/fhir/r4/search.html#id) of the resource)
+    *Implementation Notes:* Fetches a single MedicationRequest ([how to search by id of the resource](https://hl7.org/fhir/r4/search.html#id))
 
 1. **SHOULD** support searching using the combination of the **[`patient`](https://hl7.org/fhir/R4/medicationrequest.html#search)** and **[`intent`](https://hl7.org/fhir/R4/medicationrequest.html#search)** and **[`authoredon`](https://hl7.org/fhir/R4/medicationrequest.html#search)** search parameters:
     - **SHOULD** support these **[`_include`](http://hl7.org/fhir/R4/search.html#include)** parameters: `MedicationRequest:medication`

--- a/input/intro-notes/StructureDefinition-au-core-organization-notes.md
+++ b/input/intro-notes/StructureDefinition-au-core-organization-notes.md
@@ -82,5 +82,5 @@ The following search parameters **SHOULD** be supported:
     
       1. GET [base]/Organization?_id=5678
 
-    *Implementation Notes:* Fetches a single Organization ([how to search by id of the resource](https://hl7.org/fhir/r4/search.html#id) of the resource)
+    *Implementation Notes:* Fetches a single Organization ([how to search by id of the resource](https://hl7.org/fhir/r4/search.html#id))
 

--- a/input/intro-notes/StructureDefinition-au-core-organization-notes.md
+++ b/input/intro-notes/StructureDefinition-au-core-organization-notes.md
@@ -82,5 +82,5 @@ The following search parameters **SHOULD** be supported:
     
       1. GET [base]/Organization?_id=5678
 
-    *Implementation Notes:* Fetches a single Organization ([how to search by the logical id](http://hl7.org/fhir/R4/references.html#logical) of the resource)
+    *Implementation Notes:* Fetches a single Organization ([how to search by id of the resource](https://hl7.org/fhir/r4/search.html#id) of the resource)
 

--- a/input/intro-notes/StructureDefinition-au-core-patient-notes.md
+++ b/input/intro-notes/StructureDefinition-au-core-patient-notes.md
@@ -94,7 +94,7 @@
       1. GET [base]/Patient/5678
       1. GET [base]/Patient?_id=5678
 
-    *Implementation Notes:* Returns a single Patient resource ([how to search by id of the resource](https://hl7.org/fhir/r4/search.html#id) of the resource)
+    *Implementation Notes:* Returns a single Patient resource ([how to search by id of the resource](https://hl7.org/fhir/r4/search.html#id))
 
 1. **SHALL** support searching a patient by an identifier using the **[`identifier`](https://hl7.org/fhir/R4/patient.html#search)** search parameter:
     

--- a/input/intro-notes/StructureDefinition-au-core-patient-notes.md
+++ b/input/intro-notes/StructureDefinition-au-core-patient-notes.md
@@ -94,7 +94,7 @@
       1. GET [base]/Patient/5678
       1. GET [base]/Patient?_id=5678
 
-    *Implementation Notes:* Returns a single Patient resource ([how to search by the logical id](http://hl7.org/fhir/R4/references.html#logical) of the resource)
+    *Implementation Notes:* Returns a single Patient resource ([how to search by id of the resource](https://hl7.org/fhir/r4/search.html#id) of the resource)
 
 1. **SHALL** support searching a patient by an identifier using the **[`identifier`](https://hl7.org/fhir/R4/patient.html#search)** search parameter:
     

--- a/input/intro-notes/StructureDefinition-au-core-practitioner-notes.md
+++ b/input/intro-notes/StructureDefinition-au-core-practitioner-notes.md
@@ -55,7 +55,7 @@ The following search parameters **SHOULD** be supported:
       1. GET [base]/Practitioner/5678
       1. GET [base]/Practitioner?_id=5678
 
-    *Implementation Notes:* Returns a single Practitioner resource ([how to search by id of the resource](https://hl7.org/fhir/r4/search.html#id) of the resource)
+    *Implementation Notes:* Returns a single Practitioner resource ([how to search by id of the resource](https://hl7.org/fhir/r4/search.html#id))
 
 1. **SHOULD** support searching for a practitioner based on text name using the **[`name`](https://hl7.org/fhir/R4/practitioner.html#search)** search parameter:
 

--- a/input/intro-notes/StructureDefinition-au-core-practitioner-notes.md
+++ b/input/intro-notes/StructureDefinition-au-core-practitioner-notes.md
@@ -55,7 +55,7 @@ The following search parameters **SHOULD** be supported:
       1. GET [base]/Practitioner/5678
       1. GET [base]/Practitioner?_id=5678
 
-    *Implementation Notes:* Returns a single Practitioner resource ([how to search by the logical id](http://hl7.org/fhir/R4/references.html#logical) of the resource)
+    *Implementation Notes:* Returns a single Practitioner resource ([how to search by id of the resource](https://hl7.org/fhir/r4/search.html#id) of the resource)
 
 1. **SHOULD** support searching for a practitioner based on text name using the **[`name`](https://hl7.org/fhir/R4/practitioner.html#search)** search parameter:
 

--- a/input/intro-notes/StructureDefinition-au-core-practitionerrole-notes.md
+++ b/input/intro-notes/StructureDefinition-au-core-practitionerrole-notes.md
@@ -91,7 +91,7 @@ The following search parameters and search parameter combinations **SHOULD** be 
       1. GET [base]/PractitionerRole/5678
       1. GET [base]/PractitionerRole?_id=5678&amp;_include=PractitionerRole:practitioner
 
-    *Implementation Notes:* Returns a single PractitionerRole resource. ([how to search by the logical id](http://hl7.org/fhir/R4/references.html#logical) of the resource)
+    *Implementation Notes:* Returns a single PractitionerRole resource. ([how to search by id of the resource](https://hl7.org/fhir/r4/search.html#id) of the resource)
 
 1. **SHOULD** support searching using the **[`specialty`](https://hl7.org/fhir/R4/practitionerrole.html#search)** search parameter:
     - **SHOULD** support these **[`_include`](http://hl7.org/fhir/R4/search.html#include)** parameters: `PractitionerRole:practitioner`

--- a/input/intro-notes/StructureDefinition-au-core-practitionerrole-notes.md
+++ b/input/intro-notes/StructureDefinition-au-core-practitionerrole-notes.md
@@ -91,7 +91,7 @@ The following search parameters and search parameter combinations **SHOULD** be 
       1. GET [base]/PractitionerRole/5678
       1. GET [base]/PractitionerRole?_id=5678&amp;_include=PractitionerRole:practitioner
 
-    *Implementation Notes:* Returns a single PractitionerRole resource. ([how to search by id of the resource](https://hl7.org/fhir/r4/search.html#id) of the resource)
+    *Implementation Notes:* Returns a single PractitionerRole resource. ([how to search by id of the resource](https://hl7.org/fhir/r4/search.html#id))
 
 1. **SHOULD** support searching using the **[`specialty`](https://hl7.org/fhir/R4/practitionerrole.html#search)** search parameter:
     - **SHOULD** support these **[`_include`](http://hl7.org/fhir/R4/search.html#include)** parameters: `PractitionerRole:practitioner`


### PR DESCRIPTION
Change all instances of "how to search by logical id" in Notes to "how to search by id of the resource" and hyperlink to https://hl7.org/fhir/r4/search.html#id