### PR TITLE
Marked AU Core Sex Assigned at Birth as FMM=1 & status=active (FHIR-6161)

### DIFF
--- a/input/resources/au-core-rsg-sexassignedab.xml
+++ b/input/resources/au-core-rsg-sexassignedab.xml
@@ -2,11 +2,12 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="au-core-rsg-sexassignedab"/>
   <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
-		<valueInteger value="0"/>
+		<valueInteger value="1"/>
 	</extension>
   <url value="http://hl7.org.au/fhir/core/StructureDefinition/au-core-rsg-sexassignedab"/>
   <name value="AUCoreSexAssignedAtBirth"/>
   <title value="AU Core Sex Assigned At Birth"/>
+  <status value="active" />
   <description value="This profile defines the minimum expectations for a [Person Recorded Sex or Gender extension](https://build.fhir.org/ig/hl7au/au-fhir-base//StructureDefinition-individual-recordedSexOrGender.html) when representing Sex Assigned at Birth. This profile identifies the *additional* mandatory core elements, extensions, vocabularies and value sets that **SHALL** be present in the Extension when conforming to this profile." />
   <kind value="complex-type"/>
   <abstract value="false"/>


### PR DESCRIPTION
Fix for [FHIR-46161](https://jira.hl7.org/browse/FHIR-46161).

Marked AU Core Sex Assigned at Birth as FMM=1 & status=active

