### PR TITLE
Variance statement 

### DIFF
--- a/input/pagecontent/variance.md
+++ b/input/pagecontent/variance.md
@@ -4,13 +4,5 @@ This implementation guide has no variance (i.e. fully compliant) from AU Base FH
 #### Additionally Profiled Resources
 This implementation guide profiles the following resources that are not profiled in AU Base:
 
-- Observation
-  - [AU Core Blood Pressure](https://build.fhir.org/ig/hl7au/au-fhir-core/StructureDefinition-au-core-bloodpressure.html)
-  - [AU Core Body Height](https://build.fhir.org/ig/hl7au/au-fhir-core/StructureDefinition-au-core-bodyheight.html)
-  - [AU Core Body Temperature](https://build.fhir.org/ig/hl7au/au-fhir-core/StructureDefinition-au-core-bodytemp.html)
-  - [AU Core Body Weight](https://build.fhir.org/ig/hl7au/au-fhir-core/StructureDefinition-au-core-bodyweight.html)
-  - [AU Core Diagnostic Result Observation](https://build.fhir.org/ig/hl7au/au-fhir-core/StructureDefinition-au-core-diagnosticresult.html)
-  - [AU Core Heart Rate](https://build.fhir.org/ig/hl7au/au-fhir-core/StructureDefinition-au-core-heartrate.html)
-  - [AU Core Respiration Rate](https://build.fhir.org/ig/hl7au/au-fhir-core/StructureDefinition-au-core-resprate.html)
-  - [AU Core Smoking Status](https://build.fhir.org/ig/hl7au/au-fhir-core/StructureDefinition-au-core-smokingstatus.html)
-  - [AU Core Waist Circumference](https://build.fhir.org/ig/hl7au/au-fhir-core/StructureDefinition-au-core-waistcircum.html)
+- Extension
+  - [AU Core Sex Assigned At Birth](https://build.fhir.org/ig/hl7au/au-fhir-core/StructureDefinition-au-core-rsg-sexassignedab.html)  

--- a/input/pagecontent/variance.md
+++ b/input/pagecontent/variance.md
@@ -1,8 +1,23 @@
+AU Realm FHIR implementation guide projects are required to follow specific publishing guidelines:
+- **SHOULD** use AU Core profiles
+- **SHOULD** use AU Base profiles and extensions
+
+If a FHIR implementation guide cannot comply with an AU Core profile or reuse an AU Base extension, or fails to comply with an AU Base profile, it must document the variance.
+
+The Variance Statement identifies where an AU Realm FHIR implementation guide does not meet the expectations set by AU Base and/or AU Core. It also identifies resources not profiled in AU Base or AU Core, facilitating the FHIR Work Group's assessment for potential further development. Additionally, the Variance Statement page indicates where the AU Realm FHIR IG fully complies with AU Base or AU Core.
+
+The Variance Statement undergoes review and assessment by the FHIR Work Group as part of the FHIR IG balloting process. For more details on the requirements of a Variance Statement, refer to [AU FHIR IG Variance Requirements](https://confluence.hl7.org/display/HA/Process%3A++AU+FHIR+IG+Variance+Requirements).
+
+
 ### Variance from AU Base
 This implementation guide has no variance (i.e. fully compliant) from AU Base FHIR Implementation Guide version 4.2.1-ci-build ([current](https://build.fhir.org/ig/hl7au/au-fhir-base/)).
 
 #### Additionally Profiled Resources
-This implementation guide profiles the following resources that are not profiled in AU Base:
+
+This implementation guide profiles the following resources that are not profiled in AU Base: 
+
+For FHIR implementation guides that introduce profiles not present in AU Base or AU Core Implementation Guides, the HL7 FHIRWG recommends listing all of these profiles. This will assists in identifying  potential profiles for the FHIRWG to develop further.
+
 
 - Extension
-  - [AU Core Sex Assigned At Birth](https://build.fhir.org/ig/hl7au/au-fhir-core/StructureDefinition-au-core-rsg-sexassignedab.html)  
+  - [AU Core Sex Assigned At Birth](https://build.fhir.org/ig/hl7au/au-fhir-core/StructureDefinition-au-core-rsg-sexassignedab.html) profiles core FHIR extension [Person Recorded Sex Or Gender](http://hl7.org/fhir/StructureDefinition/individual-recordedSexOrGender)   


### PR DESCRIPTION
Updates to variance statement to 
- add AU Sex Assigned at Birth profile as agreed in [2024-07-03 FHIRWG Meeting Minutes](https://confluence.hl7.org/display/HAFWG/2024-07-03+FHIRWG+Meeting+Minutes)
- remove Observations profiles as the Observation resource is profiled in AU Base (only where a resource is not profiled in AU Base should those additional profiles be added)