### PR TITLE
AU Core Encounter :: add obligations to Encounter.reasonReference and remove obsolete guidance

### DIFF
--- a/input/intro-notes/StructureDefinition-au-core-encounter-intro.md
+++ b/input/intro-notes/StructureDefinition-au-core-encounter-intro.md
@@ -18,7 +18,6 @@ Conformance in reverse is not guaranteed, i.e. a resource conforming to [US Core
 
 
 ### Profile specific implementation guidance
-- The use of coding can vary significantly across systems, requesters need to understand that they may encounter codes they do not recognise and be prepared to handle those resources appropriately. Responders **SHOULD** populate `Encounter.code.text` and/or `Encounter.code.coding.display` so that requesters can at least display the condition even if the requester does not recognise the code supplied. 
 - The Encounter resource can represent a reason as a code with `Encounter.reasonCode`, or a reference with `Encounter.reasonReference` to a Condition or other resource.
   - Although both are marked as *Must Support*, responders are not required to support both a code and a reference, but they **SHALL** support *at least one* of these elements
   - A requester **SHALL** support both elements

--- a/input/resources/au-core-encounter.xml
+++ b/input/resources/au-core-encounter.xml
@@ -2,7 +2,7 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="au-core-encounter"/>
   <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
-    <valueInteger value="1"/> 
+    <valueInteger value="1"/>
   </extension>
   <url value="http://hl7.org.au/fhir/core/StructureDefinition/au-core-encounter"/>
   <name value="AUCoreEncounter"/>
@@ -214,6 +214,22 @@
       <mustSupport value="true"/>
     </element>
     <element id="Encounter.reasonReference">
+      <extension url="http://hl7.org/fhir/StructureDefinition/obligation">
+        <extension url="code">
+          <valueCode value="SHALL:populate-if-known"/>
+        </extension>
+        <extension url="actor">
+          <valueCanonical value="http://hl7.org.au/fhir/core/ActorDefinition/au-core-actor-responder"/>
+        </extension>
+      </extension>
+      <extension url="http://hl7.org/fhir/StructureDefinition/obligation">
+        <extension url="code">
+          <valueCode value="SHALL:no-error"/>
+        </extension>
+        <extension url="actor">
+          <valueCanonical value="http://hl7.org.au/fhir/core/ActorDefinition/au-core-actor-requester"/>
+        </extension>
+      </extension>
       <path value="Encounter.reasonReference"/>
       <type>
         <code value="Reference"/>


### PR DESCRIPTION
This PR addresses issues identified during the ADHA QA review.

Changes: 
- added obligations to Encounter.reasonReference
- removed implementation guidance that refers to a non-existing element Encounter.code