### PR TITLE
AU Core MedicationRequest and AU Core Procedure - add obligations to .reasonReference

### DIFF
--- a/input/resources/au-core-medicationrequest.xml
+++ b/input/resources/au-core-medicationrequest.xml
@@ -296,6 +296,22 @@
       <mustSupport value="true"/>
     </element>
     <element id="MedicationRequest.reasonReference">
+      <extension url="http://hl7.org/fhir/StructureDefinition/obligation">
+        <extension url="code">
+          <valueCode value="SHALL:populate-if-known"/>
+        </extension>
+        <extension url="actor">
+          <valueCanonical value="http://hl7.org.au/fhir/core/ActorDefinition/au-core-actor-responder"/>
+        </extension>
+      </extension>
+      <extension url="http://hl7.org/fhir/StructureDefinition/obligation">
+        <extension url="code">
+          <valueCode value="SHALL:no-error"/>
+        </extension>
+        <extension url="actor">
+          <valueCanonical value="http://hl7.org.au/fhir/core/ActorDefinition/au-core-actor-requester"/>
+        </extension>
+      </extension>
       <path value="MedicationRequest.reasonReference"/>
     <type>
         <code value="Reference"/>

--- a/input/resources/au-core-procedure.xml
+++ b/input/resources/au-core-procedure.xml
@@ -150,6 +150,22 @@
       <mustSupport value="true"/>
     </element>
     <element id="Procedure.reasonReference">
+      <extension url="http://hl7.org/fhir/StructureDefinition/obligation">
+        <extension url="code">
+          <valueCode value="SHALL:populate-if-known"/>
+        </extension>
+        <extension url="actor">
+          <valueCanonical value="http://hl7.org.au/fhir/core/ActorDefinition/au-core-actor-responder"/>
+        </extension>
+      </extension>
+      <extension url="http://hl7.org/fhir/StructureDefinition/obligation">
+        <extension url="code">
+          <valueCode value="SHALL:no-error"/>
+        </extension>
+        <extension url="actor">
+          <valueCanonical value="http://hl7.org.au/fhir/core/ActorDefinition/au-core-actor-requester"/>
+        </extension>
+      </extension>
       <path value="Procedure.reasonReference"/>
       <type>
         <code value="Reference"/>


### PR DESCRIPTION
Changes to add missing obligations to:
- MedicationRequest.reasonReference in AU Core MedicationRequest
- Procedure.reasonReference in AU Core Procedure