### PR TITLE
Updated 'how to read this guide' in line with latest changes

### DIFF
--- a/input/ig.xml
+++ b/input/ig.xml
@@ -794,15 +794,20 @@
 				<generation value="markdown"/>
 			</page>
 			<page>
+				<nameUrl value="support.html"/>
+				<title value="Support"/>
+				<generation value="markdown"/>
+			</page>
+				<page>
 				<nameUrl value="downloads.html"/>
 				<title value="Downloads"/>
 				<generation value="markdown"/>
-			</page>
-			<page>
+				</page>
+				<page>
 				<nameUrl value="license.html"/>
 				<title value="License and Legal"/>
 				<generation value="markdown"/>
-			</page>
+				</page>
 			<page>
 				<nameUrl value="changes.html"/>
 				<title value="Change Log"/>

--- a/input/ig.xml
+++ b/input/ig.xml
@@ -734,7 +734,7 @@
 				</page>
 				<page>
 					<nameUrl value="aucdi.html"/>
-					<title value="AUCDI"/>
+					<title value="AU Core Data for Interoperability"/>
 					<generation value="markdown"/>
 				</page>
 				<page>

--- a/input/pagecontent/conformance.md
+++ b/input/pagecontent/conformance.md
@@ -1,5 +1,5 @@
 - [General Requirements](general-requirements.html)
-
+- [Declaring Conformance](declaring-conformance.html)
 
 
 

--- a/input/pagecontent/guidance.md
+++ b/input/pagecontent/guidance.md
@@ -1,5 +1,7 @@
 - [General Guidance](general-guidance.html)
+- [Medicine Information](medicine-information.html)
 - [AUCDI](aucdi.html)
 - [Relationship with other IGs](relationship.html)
+- [AU Variance Statement](variance.html)
 - [Comparison with other national and international IGs](comparison.html)
 - [Future of AU Core](future.html)

--- a/input/pagecontent/index.md
+++ b/input/pagecontent/index.md
@@ -120,7 +120,7 @@ This guide is divided into several pages which are listed at the top of each pag
   - [AU Variance Statement](variance.html): This page documents the variance from AU Base.
   - [Comparison with other national and international IGs](comparison.html): This page provides comparison between AU Core profiles and other national, or international implementation guides.
   - [Future of AU Core](future.html): This page outlines the approach to developing AU Core and yearly update cycle.
-- [Security and Privacy](security.html): This page outlines the security and privacy obligations to consider when implementing AU Core.
+- [Security and Privacy](security.html): This page documents the AU Core general security and privacy requirements and recommendations.
 - [FHIR Artefacts](artifacts.html): These pages provide detailed descriptions and formal definitions for all the FHIR artefacts defined in this guide.
   - [Profiles and Extensions](profiles-and-extensions.html): This set of pages describes the profiles and extensions that are defined in this guide to exchange quality data. Each profile page includes a narrative description and guidance, formal definition and a "Quick Start" guide which summarises the supported search transactions for each profile. Although the guidance typically focuses on the profiled elements, it may also may focus on un-profiled elements to aid with implementation.
   - [Search Parameters](search-parameters.html): This set of pages lists the search parameters extended for use in this guide for use in AU Core operations.
@@ -128,9 +128,9 @@ This guide is divided into several pages which are listed at the top of each pag
   - [Capability Statements](capability-statements.html): This set of pages define the expected FHIR capabilities of AU Core Responders and Requesters.
   - [Actor Definitions](actors.html): This set of pages define the AU Core actors, AU Core Responder and AU Core Requester.
 - [Examples](examples.html): This page lists all the examples used in this guide.
-- [Support](support.html): These pages provide supporting material for implementation or AU Core.    
-  - [Downloads](downloads.html): This page provides links to downloadable artefacts that developers can use to help them implement this guide.
-  - [License and Legal](license.html): This page outlines license and legal considerations relating to FHIR Implementation Guides.
+- [Support](support.html): These pages provide supporting material for implementation of AU Core.    
+  - [Downloads](downloads.html): This page provides links to downloadable artefacts.
+  - [License and Legal](license.html): This page outlines the license and legal requirements for material in AU Core.
 - [Change Log](changes.html): This page documents the changes across versions of this guide.
 
 ### Collaboration

--- a/input/pagecontent/index.md
+++ b/input/pagecontent/index.md
@@ -109,10 +109,10 @@ The following are simple examples of AU Core FHIR RESTful interactions between A
 This guide is divided into several pages which are listed at the top of each page in the menu bar.
 
 - [Home](index.html): This page provides the introduction and scope for this guide.
-- [Conformance](conformance.html): This page describes the set of rules to claim conformance to this guide including the expectations for *Must Support*  elements in AU Core profiles.
+- [Conformance](conformance.html): These pages describe the set of rules to claim conformance to this guide including the expectations for *Must Support*  elements in AU Core profiles.
   - [General Requirements](general-requirements.html): This page defines requirements common to all actors and profiles used in this guide including how CapabilityStatements are used to claim conformance. This page defines the expectations for mandatory and *Must Support*  elements in AU Core Profiles.
   - [Declaring Conformance](declaring-conformance.html): This page describes how to declare conformance to AU Core.
-- [Guidance](guidance.html): This set of pages lists the guidance for this guide.
+- [Guidance](guidance.html): These pages list the guidance for this guide.
   - [General Guidance](general-guidance.html): This page provides guidance on using the profiles defined in this guide.
   - [Medicine Information](medicine-information.html): This page provides guidance on constructing medications related resources.
   - [AU Core Data for Interoperability](aucdi.html): This page maps the AU Core resources and elements to AUCDI data classes and data elements.
@@ -122,11 +122,11 @@ This guide is divided into several pages which are listed at the top of each pag
   - [Future of AU Core](future.html): This page outlines the approach to developing AU Core and yearly update cycle.
 - [Security and Privacy](security.html): This page documents the AU Core general security and privacy requirements and recommendations.
 - [FHIR Artefacts](artifacts.html): These pages provide detailed descriptions and formal definitions for all the FHIR artefacts defined in this guide.
-  - [Profiles and Extensions](profiles-and-extensions.html): This set of pages describes the profiles and extensions that are defined in this guide to exchange quality data. Each profile page includes a narrative description and guidance, formal definition and a "Quick Start" guide which summarises the supported search transactions for each profile. Although the guidance typically focuses on the profiled elements, it may also may focus on un-profiled elements to aid with implementation.
-  - [Search Parameters](search-parameters.html): This set of pages lists the search parameters extended for use in this guide for use in AU Core operations.
-  - [Terminology](terminology.html): This set of pages lists the value sets and code systems defined in this guide.
-  - [Capability Statements](capability-statements.html): This set of pages define the expected FHIR capabilities of AU Core Responders and Requesters.
-  - [Actor Definitions](actors.html): This set of pages define the AU Core actors, AU Core Responder and AU Core Requester.
+  - [Profiles and Extensions](profiles-and-extensions.html): This page describes the profiles and extensions that are defined in this guide to exchange quality data. Each profile page includes a narrative description and guidance, formal definition and a "Quick Start" guide which summarises the supported search transactions for each profile. Although the guidance typically focuses on the profiled elements, it may also may focus on un-profiled elements to aid with implementation.
+  - [Search Parameters](search-parameters.html): This page lists the search parameters extended for use in this guide for use in AU Core operations.
+  - [Terminology](terminology.html): This page lists the value sets and code systems defined in this guide.
+  - [Capability Statements](capability-statements.html): These pages define the expected FHIR capabilities of AU Core Responders and Requesters.
+  - [Actor Definitions](actors.html): These pages define the AU Core actors, AU Core Responder and AU Core Requester.
 - [Examples](examples.html): This page lists all the examples used in this guide.
 - [Support](support.html): These pages provide supporting material for implementation of AU Core.    
   - [Downloads](downloads.html): This page provides links to downloadable artefacts.

--- a/input/pagecontent/index.md
+++ b/input/pagecontent/index.md
@@ -115,8 +115,8 @@ This guide is divided into several pages which are listed at the top of each pag
 - [Guidance](guidance.html): These pages list the guidance for this guide.
   - [General Guidance](general-guidance.html): This page provides guidance on using the profiles defined in this guide.
   - [Medicine Information](medicine-information.html): This page provides guidance on constructing medications related resources.
-  - [AU Core Data for Interoperability](aucdi.html): This page provides guidance on the relationship between AU Core, AUCDI, and other implementation guides.
-  - [Relationship with other IGs](relationship.html): This page provides guidance on the relationship between AU Core and other implementation guides.
+  - [AU Core Data for Interoperability](aucdi.html): This page maps AUCDI data groups and elements to FHIR artefacts in AU Core.
+  - [Relationship with other IGs](relationship.html): This page provides guidance on the relationship between AU Core, AUCDI, and other implementation guides.
   - [AU Variance Statement](variance.html): This page documents the variance from AU Base.
   - [Comparison with other national and international IGs](comparison.html): This page provides comparison between AU Core profiles and other national, or international implementation guides.
   - [Future of AU Core](future.html): This page outlines the approach to developing AU Core and yearly update cycle.

--- a/input/pagecontent/index.md
+++ b/input/pagecontent/index.md
@@ -117,10 +117,10 @@ This guide is divided into several pages which are listed at the top of each pag
   - [Medicine Information](medicine-information.html): This page provides guidance on constructing medications related resources.
   - [AUCDI](aucdi.html): This page maps the AU Core resources and elements to AUCDI data classes and data elements.
   - [Relationship with other IGs](relationship.html): This page provides guidance on the relationship between AU Core and other implementation guides.
-  - [Comparison with other national and international specifications](comparison.html): This page provides comparison between AU Core profiles and other national, or international implementation guides.
   - [AU Variance Statement](variance.html): This page documents the variance from AU Base.
   - [Comparison with other national and international IGs](comparison.html): This page provides comparison between AU Core profiles and other national, or international implementation guides.
   - [Future of AU Core](future.html): This page outlines the approach to developing AU Core and yearly update cycle.
+- [Security and Privacy](security.html): This page outlines the security and privacy obligations to consider when implementing AU Core.
 - [FHIR Artefacts](artifacts.html): These pages provide detailed descriptions and formal definitions for all the FHIR artefacts defined in this guide.
   - [Profiles and Extensions](profiles-and-extensions.html): This set of pages describes the profiles and extensions that are defined in this guide to exchange quality data. Each profile page includes a narrative description and guidance, formal definition and a "Quick Start" guide which summarises the supported search transactions for each profile. Although the guidance typically focuses on the profiled elements, it may also may focus on un-profiled elements to aid with implementation.
   - [Search Parameters](search-parameters.html): This set of pages lists the search parameters extended for use in this guide for use in AU Core operations.
@@ -128,7 +128,9 @@ This guide is divided into several pages which are listed at the top of each pag
   - [Capability Statements](capability-statements.html): This set of pages define the expected FHIR capabilities of AU Core Responders and Requesters.
   - [Actor Definitions](actors.html): This set of pages define the AU Core actors, AU Core Responder and AU Core Requester.
 - [Examples](examples.html): This page lists all the examples used in this guide.
-- [Downloads](downloads.html): This page provides links to downloadable artefacts that developers can use to help them implement this guide.
+- [Support](support.html): These pages provide supporting material for implementation or AU Core.    
+  - [Downloads](downloads.html): This page provides links to downloadable artefacts that developers can use to help them implement this guide.
+  - [License and Legal](license.html): This page outlines license and legal considerations relating to FHIR Implementation Guides.
 - [Change Log](changes.html): This page documents the changes across versions of this guide.
 
 ### Collaboration

--- a/input/pagecontent/index.md
+++ b/input/pagecontent/index.md
@@ -115,16 +115,16 @@ This guide is divided into several pages which are listed at the top of each pag
 - [Guidance](guidance.html): These pages list the guidance for this guide.
   - [General Guidance](general-guidance.html): This page provides guidance on using the profiles defined in this guide.
   - [Medicine Information](medicine-information.html): This page provides guidance on constructing medications related resources.
-  - [AU Core Data for Interoperability](aucdi.html): This page maps the AU Core resources and elements to AUCDI data classes and data elements.
+  - [AU Core Data for Interoperability](aucdi.html): This page maps AUCDI data groups and elements to FHIR artefacts in AU Core.
   - [Relationship with other IGs](relationship.html): This page provides guidance on the relationship between AU Core and other implementation guides.
   - [AU Variance Statement](variance.html): This page documents the variance from AU Base.
   - [Comparison with other national and international IGs](comparison.html): This page provides comparison between AU Core profiles and other national, or international implementation guides.
   - [Future of AU Core](future.html): This page outlines the approach to developing AU Core and yearly update cycle.
 - [Security and Privacy](security.html): This page documents the AU Core general security and privacy requirements and recommendations.
 - [FHIR Artefacts](artifacts.html): These pages provide detailed descriptions and formal definitions for all the FHIR artefacts defined in this guide.
-  - [Profiles and Extensions](profiles-and-extensions.html): This page describes the profiles and extensions that are defined in this guide to exchange quality data. Each profile page includes a narrative description and guidance, formal definition and a "Quick Start" guide which summarises the supported search transactions for each profile. Although the guidance typically focuses on the profiled elements, it may also may focus on un-profiled elements to aid with implementation.
+  - [Profiles and Extensions](profiles-and-extensions.html): This page describes the profiles and extensions that are defined in this guide to exchange data. Each profile page includes a narrative description and guidance, formal definition and a "Quick Start" guide which summarises the supported search transactions for each profile. Although the guidance typically focuses on the profiled elements, it may also may focus on un-profiled elements to aid with implementation.
   - [Search Parameters](search-parameters.html): This page lists the search parameters extended for use in this guide for use in AU Core operations.
-  - [Terminology](terminology.html): This page lists the value sets and code systems defined in this guide.
+  - [Terminology](terminology.html): This page lists the value sets and code systems supported in this guide.
   - [Capability Statements](capability-statements.html): This page defines the expected FHIR capabilities of AU Core Responders and Requesters.
   - [Actor Definitions](actors.html): This page defines the AU Core actors, AU Core Responder and AU Core Requester.
 - [Examples](examples.html): This page lists all the examples used in this guide.

--- a/input/pagecontent/index.md
+++ b/input/pagecontent/index.md
@@ -115,14 +115,14 @@ This guide is divided into several pages which are listed at the top of each pag
 - [Guidance](guidance.html): These pages list the guidance for this guide.
   - [General Guidance](general-guidance.html): This page provides guidance on using the profiles defined in this guide.
   - [Medicine Information](medicine-information.html): This page provides guidance on constructing medications related resources.
-  - [AU Core Data for Interoperability](aucdi.html): This page maps AUCDI data groups and elements to FHIR artefacts in AU Core.
+  - [AU Core Data for Interoperability](aucdi.html): This page provides guidance on the relationship between AU Core, AUCDI, and other implementation guides.
   - [Relationship with other IGs](relationship.html): This page provides guidance on the relationship between AU Core and other implementation guides.
   - [AU Variance Statement](variance.html): This page documents the variance from AU Base.
   - [Comparison with other national and international IGs](comparison.html): This page provides comparison between AU Core profiles and other national, or international implementation guides.
   - [Future of AU Core](future.html): This page outlines the approach to developing AU Core and yearly update cycle.
 - [Security and Privacy](security.html): This page documents the AU Core general security and privacy requirements and recommendations.
 - [FHIR Artefacts](artifacts.html): These pages provide detailed descriptions and formal definitions for all the FHIR artefacts defined in this guide.
-  - [Profiles and Extensions](profiles-and-extensions.html): This page describes the profiles and extensions that are defined in this guide to exchange data. Each profile page includes a narrative description and guidance, formal definition and a "Quick Start" guide which summarises the supported search transactions for each profile. Although the guidance typically focuses on the profiled elements, it may also may focus on un-profiled elements to aid with implementation.
+  - [Profiles and Extensions](profiles-and-extensions.html): This page describes the profiles and extensions that are defined in this guide to exchange data. Each profile page includes a narrative description and guidance, formal definition and a "Notes" section that summarises the supported search transactions for each profile. Although the guidance typically focuses on the profiled elements, it may also may focus on un-profiled elements to aid with implementation.
   - [Search Parameters](search-parameters.html): This page lists the search parameters extended for use in this guide for use in AU Core operations.
   - [Terminology](terminology.html): This page lists the value sets and code systems supported in this guide.
   - [Capability Statements](capability-statements.html): This page defines the expected FHIR capabilities of AU Core Responders and Requesters.

--- a/input/pagecontent/index.md
+++ b/input/pagecontent/index.md
@@ -115,7 +115,7 @@ This guide is divided into several pages which are listed at the top of each pag
 - [Guidance](guidance.html): This set of pages lists the guidance for this guide.
   - [General Guidance](general-guidance.html): This page provides guidance on using the profiles defined in this guide.
   - [Medicine Information](medicine-information.html): This page provides guidance on constructing medications related resources.
-  - [AUCDI](aucdi.html): This page maps the AU Core resources and elements to AUCDI data classes and data elements.
+  - [AU Core Data for Interoperability](aucdi.html): This page maps the AU Core resources and elements to AUCDI data classes and data elements.
   - [Relationship with other IGs](relationship.html): This page provides guidance on the relationship between AU Core and other implementation guides.
   - [AU Variance Statement](variance.html): This page documents the variance from AU Base.
   - [Comparison with other national and international IGs](comparison.html): This page provides comparison between AU Core profiles and other national, or international implementation guides.

--- a/input/pagecontent/index.md
+++ b/input/pagecontent/index.md
@@ -125,8 +125,8 @@ This guide is divided into several pages which are listed at the top of each pag
   - [Profiles and Extensions](profiles-and-extensions.html): This page describes the profiles and extensions that are defined in this guide to exchange quality data. Each profile page includes a narrative description and guidance, formal definition and a "Quick Start" guide which summarises the supported search transactions for each profile. Although the guidance typically focuses on the profiled elements, it may also may focus on un-profiled elements to aid with implementation.
   - [Search Parameters](search-parameters.html): This page lists the search parameters extended for use in this guide for use in AU Core operations.
   - [Terminology](terminology.html): This page lists the value sets and code systems defined in this guide.
-  - [Capability Statements](capability-statements.html): These pages define the expected FHIR capabilities of AU Core Responders and Requesters.
-  - [Actor Definitions](actors.html): These pages define the AU Core actors, AU Core Responder and AU Core Requester.
+  - [Capability Statements](capability-statements.html): This page defines the expected FHIR capabilities of AU Core Responders and Requesters.
+  - [Actor Definitions](actors.html): This page defines the AU Core actors, AU Core Responder and AU Core Requester.
 - [Examples](examples.html): This page lists all the examples used in this guide.
 - [Support](support.html): These pages provide supporting material for implementation of AU Core.    
   - [Downloads](downloads.html): This page provides links to downloadable artefacts.

--- a/input/pagecontent/support.md
+++ b/input/pagecontent/support.md
@@ -1,0 +1,10 @@
+- [Downloads](downloads.html)
+- [License and Legal](license.html)
+
+
+
+
+
+
+
+


### PR DESCRIPTION
- Add missing conformance sub page (declaring conformance)
- Add missing guidance sub pages (med info, variance statement)
- Add security and privacy point
- Add 'support' header page in line with other headers
- Remove duplicated comparison with other IGs point.