### PR TITLE
Fixes to add in missing CapabilityStatement documentation

### DIFF
--- a/input/resources/au-core-requester.xml
+++ b/input/resources/au-core-requester.xml
@@ -2883,7 +2883,7 @@
 <mode value="client"/>
 <documentation value="The AU Core Requester **SHALL**:&#xA;1. Support the AU Core Patient resource profile.&#xA;1. Support at least one additional resource profile from the list of AU Core Profiles.&#xA;1. Implement the RESTful behavior according to the FHIR specification.&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;1. Support JSON source formats for all AU Core interactions.&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;The AU Core Requester **SHOULD**:&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;1. Support XML source formats for all AU Core interactions."/>
 <security>
-<description value="TBD requirements and recommendations."/>
+<description value="See the [Security and Privacy](security.html) page for AU Core security requirements."/>
 </security>
 <!-- ALLERGYINTOLERANCE :: DONE -->
 <resource>

--- a/input/resources/au-core-requester.xml
+++ b/input/resources/au-core-requester.xml
@@ -3122,7 +3122,7 @@
 <name value="code"/>
 <definition value="http://hl7.org/fhir/SearchParameter/clinical-code"/>
 <type value="token"/>
-<documentation value="The requester **SHALL** provide at least a code value and **MAY** provide both the system and code values.&#xA;&#xA;The responder **SHALL** support both.&#xa;&#xa;The requester **SHOULD** support `multipleOr`.&#xa;&#xa;The responder **SHOULD** support `multipleOr`."/>
+<documentation value="The requester **SHALL** provide at least a code value and **MAY** provide both the system and code values.&#xA;&#xA;The responder **SHALL** support both.&#xa;&#xa;The requester **SHALL** support `multipleOr`.&#xa;&#xa;The responder **SHALL** support `multipleOr`."/>
 </searchParam>
 <searchParam>
 <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
@@ -3282,7 +3282,7 @@
 <name value="status"/>
 <definition value="http://hl7.org/fhir/SearchParameter/DocumentReference-status"/>
 <type value="token"/>
-<documentation value="The requester **SHALL** provide at least a code value and **MAY** provide both the system and code values.&#xA;&#xA;The responder **SHALL** support both.&#xa;&#xa;The requester **SHOULD** support `multipleOr`.&#xa;&#xa;The responder **SHOULD** support `multipleOr`."/>
+<documentation value="The requester **SHALL** provide at least a code value and **MAY** provide both the system and code values.&#xA;&#xA;The responder **SHALL** support both.&#xa;&#xa;The requester **SHALL** support `multipleOr`.&#xa;&#xa;The responder **SHALL** support `multipleOr`."/>
 </searchParam>
 <searchParam>
 <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
@@ -3732,7 +3732,7 @@
 <name value="status"/>
 <definition value="http://hl7.org/fhir/SearchParameter/medications-status"/>
 <type value="token"/>
-<documentation value="The requester **SHALL** provide at least a code value and **MAY** provide both the system and code values.&#xA;&#xA;The responder **SHALL** support both.&#xa;&#xa;The requester **SHOULD** support `multipleOr`.&#xa;&#xa;The responder **SHOULD** support `multipleOr`."/>
+<documentation value="The requester **SHALL** provide at least a code value and **MAY** provide both the system and code values.&#xA;&#xA;The responder **SHALL** support both.&#xa;&#xa;The requester **SHALL** support `multipleOr`.&#xa;&#xa;The responder **SHALL** support `multipleOr`."/>
 </searchParam>
 <searchParam>
 <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
@@ -3934,7 +3934,7 @@
 <name value="code"/>
 <definition value="http://hl7.org/fhir/SearchParameter/clinical-code"/>
 <type value="token"/>
-<documentation value="The requester **SHALL** provide at least a code value and **MAY** provide both the system and code values.&#xA;&#xA;The responder **SHALL** support both.&#xa;&#xa;The requester **SHOULD** support `multipleOr`.&#xa;&#xa;The responder **SHOULD** support `multipleOr`."/>
+<documentation value="The requester **SHALL** provide at least a code value and **MAY** provide both the system and code values.&#xA;&#xA;The responder **SHALL** support both.&#xa;&#xa;The requester **SHALL** support `multipleOr`.&#xa;&#xa;The responder **SHALL** support `multipleOr`."/>
 </searchParam>
 <searchParam>
 <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
@@ -3952,7 +3952,7 @@
 <name value="status"/>
 <definition value="http://hl7.org/fhir/SearchParameter/Observation-status"/>
 <type value="token"/>
-<documentation value="The requester **SHALL** provide at least a code value and **MAY** provide both the system and code values.&#xA;&#xA;The responder **SHALL** support both.&#xa;&#xa;The requester **SHOULD** support `multipleOr`.&#xa;&#xa;The responder **SHOULD** support `multipleOr`."/>
+<documentation value="The requester **SHALL** provide at least a code value and **MAY** provide both the system and code values.&#xA;&#xA;The responder **SHALL** support both.&#xa;&#xa;The requester **SHALL** support `multipleOr`.&#xa;&#xa;The responder **SHALL** support `multipleOr`."/>
 </searchParam>
 <searchParam>
 <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
@@ -4532,7 +4532,7 @@
 <name value="code"/>
 <definition value="http://hl7.org/fhir/SearchParameter/clinical-code"/>
 <type value="token"/>
-<documentation value="The requester **SHALL** provide at least a code value and **MAY** provide both the system and code values.&#xA;&#xA;The responder **SHALL** support both.&#xa;&#xa;The requester **SHOULD** support `multipleOr`.&#xa;&#xa;The responder **SHOULD** support `multipleOr`."/>
+<documentation value="The requester **SHALL** provide at least a code value and **MAY** provide both the system and code values.&#xA;&#xA;The responder **SHALL** support both.&#xa;&#xa;The requester **SHALL** support `multipleOr`.&#xa;&#xa;The responder **SHALL** support `multipleOr`."/>
 </searchParam>
 <searchParam>
 <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
@@ -4550,7 +4550,7 @@
 <name value="status"/>
 <definition value="http://hl7.org/fhir/SearchParameter/Procedure-status"/>
 <type value="token"/>
-<documentation value="The requester **SHALL** provide at least a code value and **MAY** provide both the system and code values.&#xA;&#xA;The responder **SHALL** support both.&#xa;&#xa;The requester **SHOULD** support `multipleOr`.&#xa;&#xa;The responder **SHOULD** support `multipleOr`."/>
+<documentation value="The requester **SHALL** provide at least a code value and **MAY** provide both the system and code values.&#xA;&#xA;The responder **SHALL** support both.&#xa;&#xa;The requester **SHALL** support `multipleOr`.&#xa;&#xa;The responder **SHALL** support `multipleOr`."/>
 </searchParam>
 <searchParam>
 <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">

--- a/input/resources/au-core-requester.xml
+++ b/input/resources/au-core-requester.xml
@@ -705,6 +705,8 @@
   <div>
     <p>The requester <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p>
     <p>The responder <strong>SHALL</strong> support both.</p>
+    <p>The requester <strong>SHOULD</strong> support <code>multipleOr</code>.</p>
+    <p>The responder <strong>SHOULD</strong> support <code>multipleOr</code>.</p>
   </div>
 </td>
 </tr>
@@ -724,6 +726,8 @@
     <p>The responder <strong>SHALL</strong> support a value precise to the second + time offset.</p>
     <p>The requester <strong>SHALL</strong> support these search comparators <code>gt</code>, <code>lt</code>, <code>ge</code>, <code>le</code>.</p>
     <p>The responder <strong>SHALL</strong> support these search comparators <code>gt</code>, <code>lt</code>, <code>ge</code>, <code>le</code>.</p>
+    <p>The requester <strong>SHOULD</strong> support <code>multipleAnd</code>.</p>
+    <p>The responder <strong>SHOULD</strong> support <code>multipleAnd</code>.</p>
   </div>
 </td>
 </tr>
@@ -935,7 +939,9 @@
       <p>The requester <strong>SHALL</strong> provide a value precise to the second + time offset.</p>
       <p>The responder <strong>SHALL</strong> support a value precise to the second + time offset.</p>
       <p>The requester <strong>SHALL</strong> support these search comparators <code>gt</code>, <code>lt</code>, <code>ge</code>, <code>le</code>.</p>
-    <p>The responder <strong>SHALL</strong> support these search comparators <code>gt</code>, <code>lt</code>, <code>ge</code>, <code>le</code>.</p>
+      <p>The responder <strong>SHALL</strong> support these search comparators <code>gt</code>, <code>lt</code>, <code>ge</code>, <code>le</code>.</p>
+      <p>The requester <strong>SHOULD</strong> support <code>multipleAnd</code>.</p>
+      <p>The responder <strong>SHOULD</strong> support <code>multipleAnd</code>.</p>
     </div>
   </td>
 </tr>
@@ -970,6 +976,8 @@
     <div>
       <p>The requester <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p>
       <p>The responder <strong>SHALL</strong> support both.</p>
+      <p>The requester <strong>SHOULD</strong> support <code>multipleOr</code>.</p>
+      <p>The responder <strong>SHOULD</strong> support <code>multipleOr</code>.</p>
     </div>
   </td>
 </tr>
@@ -1154,6 +1162,8 @@
     <p>The responder <strong>SHALL</strong> support a value precise to the second + time offset.</p>
     <p>The requester <strong>SHALL</strong> support these search comparators <code>gt</code>, <code>lt</code>, <code>ge</code>, <code>le</code>.</p>
     <p>The responder <strong>SHALL</strong> support these search comparators <code>gt</code>, <code>lt</code>, <code>ge</code>, <code>le</code>.</p>
+    <p>The requester <strong>SHOULD</strong> support <code>multipleAnd</code>.</p>
+    <p>The responder <strong>SHOULD</strong> support <code>multipleAnd</code>.</p>
   </div>
 </td>
 </tr>
@@ -1575,6 +1585,8 @@
     <p>The responder <strong>SHALL</strong> support a value precise to the second + time offset.</p>
     <p>The requester <strong>SHALL</strong> support these search comparators <code>gt</code>, <code>lt</code>, <code>ge</code>, <code>le</code>.</p>
     <p>The responder <strong>SHALL</strong> support these search comparators <code>gt</code>, <code>lt</code>, <code>ge</code>, <code>le</code>.</p>
+    <p>The requester <strong>SHOULD</strong> support <code>multipleAnd</code>.</p>
+    <p>The responder <strong>SHOULD</strong> support <code>multipleAnd</code>.</p>
   </div>
 </td>
 </tr>
@@ -1609,6 +1621,8 @@
   <div>
     <p>The requester <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p>
     <p>The responder <strong>SHALL</strong> support both.</p>
+    <p>The requester <strong>SHOULD</strong> support <code>multipleOr</code>.</p>
+    <p>The responder <strong>SHOULD</strong> support <code>multipleOr</code>.</p>
   </div>
 </td>
 </tr>
@@ -2720,6 +2734,8 @@
   <div>
     <p>The requester <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p>
     <p>The responder <strong>SHALL</strong> support both.</p>
+    <p>The requester <strong>SHOULD</strong> support <code>multipleOr</code>.</p>
+    <p>The responder <strong>SHOULD</strong> support <code>multipleOr</code>.</p>
   </div>
 </td>
 </tr>
@@ -2739,6 +2755,8 @@
     <p>The responder <strong>SHALL</strong> support a value precise to the second + time offset.</p>
     <p>The requester <strong>SHALL</strong> support these search comparators <code>gt</code>, <code>lt</code>, <code>ge</code>, <code>le</code>.</p>
     <p>The responder <strong>SHALL</strong> support these search comparators <code>gt</code>, <code>lt</code>, <code>ge</code>, <code>le</code>.</p>
+    <p>The requester <strong>SHOULD</strong> support <code>multipleAnd</code>.</p>
+    <p>The responder <strong>SHOULD</strong> support <code>multipleAnd</code>.</p>
   </div>
 </td>
 </tr>
@@ -2756,6 +2774,8 @@
   <div>
     <p>The requester <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p>
     <p>The responder <strong>SHALL</strong> support both.</p>
+    <p>The requester <strong>SHOULD</strong> support <code>multipleOr</code>.</p>
+    <p>The responder <strong>SHOULD</strong> support <code>multipleOr</code>.</p>
   </div>
 </td>
 </tr>

--- a/input/resources/au-core-requester.xml
+++ b/input/resources/au-core-requester.xml
@@ -3102,7 +3102,7 @@
 <name value="category"/>
 <definition value="http://hl7.org/fhir/SearchParameter/Condition-category"/>
 <type value="token"/>
-<documentation value="The category of the condition"/>
+<documentation value="The requester **SHALL** provide at least a code value and **MAY** provide both the system and code values.&#xa;&#xa;The responder **SHALL** support both."/>
 </searchParam>
 <searchParam>
 <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
@@ -3120,7 +3120,7 @@
 <name value="code"/>
 <definition value="http://hl7.org/fhir/SearchParameter/clinical-code"/>
 <type value="token"/>
-<documentation value="The requester **SHALL** provide at least a code value and **MAY** provide both the system and code values.&#xA;&#xA;The responder **SHALL** support both."/>
+<documentation value="The requester **SHALL** provide at least a code value and **MAY** provide both the system and code values.&#xA;&#xA;The responder **SHALL** support both.&#xa;&#xa;The requester **SHOULD** support `multipleOr`.&#xa;&#xa;The responder **SHOULD** support `multipleOr`."/>
 </searchParam>
 <searchParam>
 <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
@@ -3129,7 +3129,7 @@
 <name value="onset-date"/>
 <definition value="http://hl7.org/fhir/SearchParameter/Condition-onset-date"/>
 <type value="date"/>
-<documentation value="A requester **SHALL** provide a value precise to the *second + time offset*.&#xA;&#xA;A responder **SHALL** support a value precise to the *second + time offset*. &#xA;&#xA;The requester **SHALL** support these search comparators `gt`, `lt`, `ge`, `le`.&#xA;&#xA;The responder **SHALL** support these search comparators `gt`, `lt`, `ge`, `le`."/>
+<documentation value="A requester **SHALL** provide a value precise to the *second + time offset*.&#xA;&#xA;A responder **SHALL** support a value precise to the *second + time offset*. &#xA;&#xA;The requester **SHALL** support these search comparators `gt`, `lt`, `ge`, `le`.&#xA;&#xA;The responder **SHALL** support these search comparators `gt`, `lt`, `ge`, `le`.&#xa;&#xa;The requester **SHOULD** support `multipleAnd`.&#xa;&#xa;The responder **SHOULD** support `multipleAnd`."/>
 </searchParam>
 <searchParam>
 <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
@@ -3262,7 +3262,7 @@
 <name value="date"/>
 <definition value="http://hl7.org/fhir/SearchParameter/clinical-date"/>
 <type value="date"/>
-<documentation value="A requester **SHALL** provide a value precise to the *second + time offset*.&#xA;&#xA;A responder **SHALL** support a value precise to the *second + time offset*. &#xA;&#xA;The requester **SHALL** support these search comparators `gt`, `lt`, `ge`, `le`.&#xA;&#xA;The responder **SHALL** support these search comparators `gt`, `lt`, `ge`, `le`."/>
+<documentation value="A requester **SHALL** provide a value precise to the *second + time offset*.&#xA;&#xA;A responder **SHALL** support a value precise to the *second + time offset*. &#xA;&#xA;The requester **SHALL** support these search comparators `gt`, `lt`, `ge`, `le`.&#xA;&#xA;The responder **SHALL** support these search comparators `gt`, `lt`, `ge`, `le`.&#xa;&#xa;The requester **SHOULD** support `multipleAnd`.&#xa;&#xa;The responder **SHOULD** support `multipleAnd`."/>
 </searchParam>
 <searchParam>
 <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
@@ -3280,7 +3280,7 @@
 <name value="status"/>
 <definition value="http://hl7.org/fhir/SearchParameter/DocumentReference-status"/>
 <type value="token"/>
-<documentation value="The requester **SHALL** provide at least a code value and **MAY** provide both the system and code values.&#xA;&#xA;The responder **SHALL** support both."/>
+<documentation value="The requester **SHALL** provide at least a code value and **MAY** provide both the system and code values.&#xA;&#xA;The responder **SHALL** support both.&#xa;&#xa;The requester **SHOULD** support `multipleOr`.&#xa;&#xa;The responder **SHOULD** support `multipleOr`."/>
 </searchParam>
 <searchParam>
 <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
@@ -3393,7 +3393,7 @@
 <name value="date"/>
 <definition value="http://hl7.org/fhir/SearchParameter/clinical-date"/>
 <type value="date"/>
-<documentation value="A requester **SHALL** provide a value precise to the *second + time offset*.&#xA;&#xA;A responder **SHALL** support a value precise to the *second + time offset*. &#xA;&#xA;The requester **SHALL** support these search comparators `gt`, `lt`, `ge`, `le`.&#xA;&#xA;The responder **SHALL** support these search comparators `gt`, `lt`, `ge`, `le`."/>
+<documentation value="A requester **SHALL** provide a value precise to the *second + time offset*.&#xA;&#xA;A responder **SHALL** support a value precise to the *second + time offset*. &#xA;&#xA;The requester **SHALL** support these search comparators `gt`, `lt`, `ge`, `le`.&#xA;&#xA;The responder **SHALL** support these search comparators `gt`, `lt`, `ge`, `le`.&#xa;&#xa;The requester **SHOULD** support `multipleAnd`.&#xa;&#xa;The responder **SHOULD** support `multipleAnd`."/>
 </searchParam>
 <searchParam>
 <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
@@ -3712,7 +3712,7 @@
 <name value="authoredon"/>
 <definition value="http://hl7.org/fhir/SearchParameter/MedicationRequest-authoredon"/>
 <type value="date"/>
-<documentation value="A requester **SHALL** provide a value precise to the *second + time offset*.&#xA;&#xA;A responder **SHALL** support a value precise to the *second + time offset*. &#xA;&#xA;The requester **SHALL** support these search comparators `gt`, `lt`, `ge`, `le`.&#xA;&#xA;The responder **SHALL** support these search comparators `gt`, `lt`, `ge`, `le`."/>
+<documentation value="A requester **SHALL** provide a value precise to the *second + time offset*.&#xA;&#xA;A responder **SHALL** support a value precise to the *second + time offset*. &#xA;&#xA;The requester **SHALL** support these search comparators `gt`, `lt`, `ge`, `le`.&#xA;&#xA;The responder **SHALL** support these search comparators `gt`, `lt`, `ge`, `le`.&#xa;&#xa;The requester **SHOULD** support `multipleAnd`.&#xa;&#xa;The responder **SHOULD** support `multipleAnd`."/>
 </searchParam>
 <searchParam>
 <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
@@ -3730,7 +3730,7 @@
 <name value="status"/>
 <definition value="http://hl7.org/fhir/SearchParameter/medications-status"/>
 <type value="token"/>
-<documentation value="The requester **SHALL** provide at least a code value and **MAY** provide both the system and code values.&#xA;&#xA;The responder **SHALL** support both."/>
+<documentation value="The requester **SHALL** provide at least a code value and **MAY** provide both the system and code values.&#xA;&#xA;The responder **SHALL** support both.&#xa;&#xa;The requester **SHOULD** support `multipleOr`.&#xa;&#xa;The responder **SHOULD** support `multipleOr`."/>
 </searchParam>
 <searchParam>
 <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
@@ -3932,7 +3932,7 @@
 <name value="code"/>
 <definition value="http://hl7.org/fhir/SearchParameter/clinical-code"/>
 <type value="token"/>
-<documentation value="The requester **SHALL** provide at least a code value and **MAY** provide both the system and code values.&#xA;&#xA;The responder **SHALL** support both."/>
+<documentation value="The requester **SHALL** provide at least a code value and **MAY** provide both the system and code values.&#xA;&#xA;The responder **SHALL** support both.&#xa;&#xa;The requester **SHOULD** support `multipleOr`.&#xa;&#xa;The responder **SHOULD** support `multipleOr`."/>
 </searchParam>
 <searchParam>
 <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
@@ -3941,7 +3941,7 @@
 <name value="date"/>
 <definition value="http://hl7.org/fhir/SearchParameter/clinical-date"/>
 <type value="date"/>
-<documentation value="A requester **SHALL** provide a value precise to the *second + time offset*.&#xA;&#xA;A responder **SHALL** support a value precise to the *second + time offset*. &#xA;&#xA;The requester **SHALL** support these search comparators `gt`, `lt`, `ge`, `le`.&#xA;&#xA;The responder **SHALL** support these search comparators `gt`, `lt`, `ge`, `le`."/>
+<documentation value="A requester **SHALL** provide a value precise to the *second + time offset*.&#xA;&#xA;A responder **SHALL** support a value precise to the *second + time offset*. &#xA;&#xA;The requester **SHALL** support these search comparators `gt`, `lt`, `ge`, `le`.&#xA;&#xA;The responder **SHALL** support these search comparators `gt`, `lt`, `ge`, `le`.&#xa;&#xa;The requester **SHOULD** support `multipleAnd`.&#xa;&#xa;The responder **SHOULD** support `multipleAnd`."/>
 </searchParam>
 <searchParam>
 <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
@@ -3950,7 +3950,7 @@
 <name value="status"/>
 <definition value="http://hl7.org/fhir/SearchParameter/Observation-status"/>
 <type value="token"/>
-<documentation value="The requester **SHALL** provide at least a code value and **MAY** provide both the system and code values.&#xA;&#xA;The responder **SHALL** support both."/>
+<documentation value="The requester **SHALL** provide at least a code value and **MAY** provide both the system and code values.&#xA;&#xA;The responder **SHALL** support both.&#xa;&#xa;The requester **SHOULD** support `multipleOr`.&#xa;&#xa;The responder **SHOULD** support `multipleOr`."/>
 </searchParam>
 <searchParam>
 <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
@@ -4530,7 +4530,7 @@
 <name value="code"/>
 <definition value="http://hl7.org/fhir/SearchParameter/clinical-code"/>
 <type value="token"/>
-<documentation value="The requester **SHALL** provide at least a code value and **MAY** provide both the system and code values.&#xA;&#xA;The responder **SHALL** support both."/>
+<documentation value="The requester **SHALL** provide at least a code value and **MAY** provide both the system and code values.&#xA;&#xA;The responder **SHALL** support both.&#xa;&#xa;The requester **SHOULD** support `multipleOr`.&#xa;&#xa;The responder **SHOULD** support `multipleOr`."/>
 </searchParam>
 <searchParam>
 <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
@@ -4539,7 +4539,7 @@
 <name value="date"/>
 <definition value="http://hl7.org/fhir/SearchParameter/clinical-date"/>
 <type value="date"/>
-<documentation value="A requester **SHALL** provide a value precise to the *second + time offset*.&#xA;&#xA;A responder **SHALL** support a value precise to the *second + time offset*. &#xA;&#xA;The requester **SHALL** support these search comparators `gt`, `lt`, `ge`, `le`.&#xA;&#xA;The responder **SHALL** support these search comparators `gt`, `lt`, `ge`, `le`."/>
+<documentation value="A requester **SHALL** provide a value precise to the *second + time offset*.&#xA;&#xA;A responder **SHALL** support a value precise to the *second + time offset*. &#xA;&#xA;The requester **SHALL** support these search comparators `gt`, `lt`, `ge`, `le`.&#xA;&#xA;The responder **SHALL** support these search comparators `gt`, `lt`, `ge`, `le`.&#xa;&#xa;The requester **SHOULD** support `multipleAnd`.&#xa;&#xa;The responder **SHOULD** support `multipleAnd`."/>
 </searchParam>
 <searchParam>
 <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
@@ -4548,7 +4548,7 @@
 <name value="status"/>
 <definition value="http://hl7.org/fhir/SearchParameter/Procedure-status"/>
 <type value="token"/>
-<documentation value="The requester **SHALL** provide at least a code value and **MAY** provide both the system and code values.&#xA;&#xA;The responder **SHALL** support both."/>
+<documentation value="The requester **SHALL** provide at least a code value and **MAY** provide both the system and code values.&#xA;&#xA;The responder **SHALL** support both.&#xa;&#xa;The requester **SHOULD** support `multipleOr`.&#xa;&#xa;The responder **SHOULD** support `multipleOr`."/>
 </searchParam>
 <searchParam>
 <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">

--- a/input/resources/au-core-requester.xml
+++ b/input/resources/au-core-requester.xml
@@ -1828,6 +1828,8 @@
   <div>
     <p>The requester <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p>
     <p>The responder <strong>SHALL</strong> support both.</p>
+    <p>The requester <strong>SHOULD</strong> support <code>multipleOr</code>.</p>
+    <p>The responder <strong>SHOULD</strong> support <code>multipleOr</code>.</p>
   </div>
 </td>
 </tr>
@@ -1847,6 +1849,8 @@
     <p>The responder <strong>SHALL</strong> support a value precise to the second + time offset.</p>
     <p>The requester <strong>SHALL</strong> support these search comparators <code>gt</code>, <code>lt</code>, <code>ge</code>, <code>le</code>.</p>
     <p>The responder <strong>SHALL</strong> support these search comparators <code>gt</code>, <code>lt</code>, <code>ge</code>, <code>le</code>.</p>
+    <p>The requester <strong>SHOULD</strong> support <code>multipleAnd</code>.</p>
+    <p>The responder <strong>SHOULD</strong> support <code>multipleAnd</code>.</p>
   </div>
 </td>
 </tr>
@@ -1864,6 +1868,8 @@
   <div>
     <p>The requester <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p>
     <p>The responder <strong>SHALL</strong> support both.</p>
+    <p>The requester <strong>SHOULD</strong> support <code>multipleOr</code>.</p>
+    <p>The responder <strong>SHOULD</strong> support <code>multipleOr</code>.</p>
   </div>
 </td>
 </tr>

--- a/input/resources/au-core-requester.xml
+++ b/input/resources/au-core-requester.xml
@@ -705,8 +705,8 @@
   <div>
     <p>The requester <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p>
     <p>The responder <strong>SHALL</strong> support both.</p>
-    <p>The requester <strong>SHOULD</strong> support <code>multipleOr</code>.</p>
-    <p>The responder <strong>SHOULD</strong> support <code>multipleOr</code>.</p>
+    <p>The requester <strong>SHALL</strong> support <code>multipleOr</code>.</p>
+    <p>The responder <strong>SHALL</strong> support <code>multipleOr</code>.</p>
   </div>
 </td>
 </tr>
@@ -976,8 +976,8 @@
     <div>
       <p>The requester <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p>
       <p>The responder <strong>SHALL</strong> support both.</p>
-      <p>The requester <strong>SHOULD</strong> support <code>multipleOr</code>.</p>
-      <p>The responder <strong>SHOULD</strong> support <code>multipleOr</code>.</p>
+      <p>The requester <strong>SHALL</strong> support <code>multipleOr</code>.</p>
+      <p>The responder <strong>SHALL</strong> support <code>multipleOr</code>.</p>
     </div>
   </td>
 </tr>
@@ -1621,8 +1621,8 @@
   <div>
     <p>The requester <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p>
     <p>The responder <strong>SHALL</strong> support both.</p>
-    <p>The requester <strong>SHOULD</strong> support <code>multipleOr</code>.</p>
-    <p>The responder <strong>SHOULD</strong> support <code>multipleOr</code>.</p>
+    <p>The requester <strong>SHALL</strong> support <code>multipleOr</code>.</p>
+    <p>The responder <strong>SHALL</strong> support <code>multipleOr</code>.</p>
   </div>
 </td>
 </tr>
@@ -1828,8 +1828,8 @@
   <div>
     <p>The requester <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p>
     <p>The responder <strong>SHALL</strong> support both.</p>
-    <p>The requester <strong>SHOULD</strong> support <code>multipleOr</code>.</p>
-    <p>The responder <strong>SHOULD</strong> support <code>multipleOr</code>.</p>
+    <p>The requester <strong>SHALL</strong> support <code>multipleOr</code>.</p>
+    <p>The responder <strong>SHALL</strong> support <code>multipleOr</code>.</p>
   </div>
 </td>
 </tr>
@@ -1868,8 +1868,8 @@
   <div>
     <p>The requester <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p>
     <p>The responder <strong>SHALL</strong> support both.</p>
-    <p>The requester <strong>SHOULD</strong> support <code>multipleOr</code>.</p>
-    <p>The responder <strong>SHOULD</strong> support <code>multipleOr</code>.</p>
+    <p>The requester <strong>SHALL</strong> support <code>multipleOr</code>.</p>
+    <p>The responder <strong>SHALL</strong> support <code>multipleOr</code>.</p>
   </div>
 </td>
 </tr>
@@ -2742,8 +2742,8 @@
   <div>
     <p>The requester <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p>
     <p>The responder <strong>SHALL</strong> support both.</p>
-    <p>The requester <strong>SHOULD</strong> support <code>multipleOr</code>.</p>
-    <p>The responder <strong>SHOULD</strong> support <code>multipleOr</code>.</p>
+    <p>The requester <strong>SHALL</strong> support <code>multipleOr</code>.</p>
+    <p>The responder <strong>SHALL</strong> support <code>multipleOr</code>.</p>
   </div>
 </td>
 </tr>
@@ -2782,8 +2782,8 @@
   <div>
     <p>The requester <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p>
     <p>The responder <strong>SHALL</strong> support both.</p>
-    <p>The requester <strong>SHOULD</strong> support <code>multipleOr</code>.</p>
-    <p>The responder <strong>SHOULD</strong> support <code>multipleOr</code>.</p>
+    <p>The requester <strong>SHALL</strong> support <code>multipleOr</code>.</p>
+    <p>The responder <strong>SHALL</strong> support <code>multipleOr</code>.</p>
   </div>
 </td>
 </tr>

--- a/input/resources/au-core-responder.xml
+++ b/input/resources/au-core-responder.xml
@@ -717,6 +717,8 @@
   <div>
     <p>The requester <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p>
     <p>The responder <strong>SHALL</strong> support both.</p>
+    <p>The requester <strong>SHOULD</strong> support <code>multipleOr</code>.</p>
+    <p>The responder <strong>SHOULD</strong> support <code>multipleOr</code>.</p>
   </div>
 </td>
 </tr>
@@ -734,10 +736,10 @@
   <div>
     <p>The requester <strong>SHALL</strong> provide a value precise to the second + time offset.</p>
     <p>The responder <strong>SHALL</strong> support a value precise to the second + time offset.</p>
-    <p>The requester <strong>SHALL</strong> support these search comparators <code>gt</code>,      <code>lt</code>,      <code>ge</code>,      <code>le</code>.        
-    </p>
-    <p>The responder <strong>SHALL</strong> support these search comparators <code>gt</code>,      <code>lt</code>,      <code>ge</code>,      <code>le</code>.        
-    </p>
+    <p>The requester <strong>SHALL</strong> support these search comparators <code>gt</code>, <code>lt</code>, <code>ge</code>, <code>le</code>.</p>
+    <p>The responder <strong>SHALL</strong> support these search comparators <code>gt</code>, <code>lt</code>, <code>ge</code>, <code>le</code>.</p>
+    <p>The requester <strong>SHOULD</strong> support <code>multipleAnd</code>.</p>
+    <p>The responder <strong>SHOULD</strong> support <code>multipleAnd</code>.</p>
   </div>
 </td>
 </tr>
@@ -948,10 +950,10 @@
     <div>
       <p>The requester <strong>SHALL</strong> provide a value precise to the second + time offset.</p>
       <p>The responder <strong>SHALL</strong> support a value precise to the second + time offset.</p>
-      <p>The requester <strong>SHALL</strong> support these search comparators <code>gt</code>,        <code>lt</code>,        <code>ge</code>,        <code>le</code>.            
-      </p>
-      <p>The responder <strong>SHALL</strong> support these search comparators <code>gt</code>,        <code>lt</code>,        <code>ge</code>,        <code>le</code>.            
-      </p>
+      <p>The requester <strong>SHALL</strong> support these search comparators <code>gt</code>, <code>lt</code>, <code>ge</code>, <code>le</code>.</p>
+      <p>The responder <strong>SHALL</strong> support these search comparators <code>gt</code>, <code>lt</code>, <code>ge</code>, <code>le</code>.</p>
+      <p>The requester <strong>SHOULD</strong> support <code>multipleAnd</code>.</p>
+      <p>The responder <strong>SHOULD</strong> support <code>multipleAnd</code>.</p>
     </div>
   </td>
 </tr>
@@ -986,6 +988,8 @@
     <div>
       <p>The requester <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p>
       <p>The responder <strong>SHALL</strong> support both.</p>
+      <p>The requester <strong>SHOULD</strong> support <code>multipleOr</code>.</p>
+      <p>The responder <strong>SHOULD</strong> support <code>multipleOr</code>.</p>
     </div>
   </td>
 </tr>
@@ -1172,6 +1176,8 @@
     </p>
     <p>The responder <strong>SHALL</strong> support these search comparators <code>gt</code>, <code>lt</code>, <code>ge</code>, <code>le</code>.        
     </p>
+    <p>The requester <strong>SHOULD</strong> support <code>multipleAnd</code>.</p>
+    <p>The responder <strong>SHOULD</strong> support <code>multipleAnd</code>.</p>
   </div>
 </td>
 </tr>
@@ -1594,6 +1600,8 @@
     </p>
     <p>The responder <strong>SHALL</strong> support these search comparators <code>gt</code>,      <code>lt</code>,      <code>ge</code>,      <code>le</code>.        
     </p>
+    <p>The requester <strong>SHOULD</strong> support <code>multipleAnd</code>.</p>
+    <p>The responder <strong>SHOULD</strong> support <code>multipleAnd</code>.</p>
   </div>
 </td>
 </tr>
@@ -1628,6 +1636,8 @@
   <div>
     <p>The requester <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p>
     <p>The responder <strong>SHALL</strong> support both.</p>
+    <p>The requester <strong>SHOULD</strong> support <code>multipleOr</code>.</p>
+    <p>The responder <strong>SHOULD</strong> support <code>multipleOr</code>.</p>
   </div>
 </td>
 </tr>
@@ -2740,6 +2750,8 @@
   <div>
     <p>The requester <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p>
     <p>The responder <strong>SHALL</strong> support both.</p>
+    <p>The requester <strong>SHOULD</strong> support <code>multipleOr</code>.</p>
+    <p>The responder <strong>SHOULD</strong> support <code>multipleOr</code>.</p>
   </div>
 </td>
 </tr>
@@ -2757,10 +2769,10 @@
   <div>
     <p>The requester <strong>SHALL</strong> provide a value precise to the second + time offset.</p>
     <p>The responder <strong>SHALL</strong> support a value precise to the second + time offset.</p>
-    <p>The requester <strong>SHALL</strong> support these search comparators <code>gt</code>,      <code>lt</code>,      <code>ge</code>,      <code>le</code>.        
-    </p>
-    <p>The responder <strong>SHALL</strong> support these search comparators <code>gt</code>,      <code>lt</code>,      <code>ge</code>,      <code>le</code>.        
-    </p>
+    <p>The requester <strong>SHALL</strong> support these search comparators <code>gt</code>, <code>lt</code>, <code>ge</code>, <code>le</code>.</p>
+    <p>The responder <strong>SHALL</strong> support these search comparators <code>gt</code>, <code>lt</code>, <code>ge</code>, <code>le</code>.</p>
+    <p>The requester <strong>SHOULD</strong> support <code>multipleAnd</code>.</p>
+    <p>The responder <strong>SHOULD</strong> support <code>multipleAnd</code>.</p>
   </div>
 </td>
 </tr>
@@ -2778,6 +2790,8 @@
   <div>
     <p>The requester <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p>
     <p>The responder <strong>SHALL</strong> support both.</p>
+    <p>The requester <strong>SHOULD</strong> support <code>multipleOr</code>.</p>
+    <p>The responder <strong>SHOULD</strong> support <code>multipleOr</code>.</p>
   </div>
 </td>
 </tr>

--- a/input/resources/au-core-responder.xml
+++ b/input/resources/au-core-responder.xml
@@ -2899,7 +2899,7 @@
 <mode value="server"/>
 <documentation value="The AU Core Responder **SHALL**:&#xA;1. Support the AU Core Patient resource profile.&#xA;1. Support at least one additional resource profile from the list of AU Core Profiles.&#xA;1. Implement the RESTful behavior according to the FHIR specification.&#xA;1. Return the following response classes:&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;   - (Status 400): invalid parameter&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;   - (Status 401/4xx): unauthorized request&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;   - (Status 403): insufficient scope&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;   - (Status 404): unknown resource&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;1. Support JSON source formats for all AU Core interactions.&#xA;1. Declare a CapabilityStatement identifying the list of profiles, operations, and search parameters supported.&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;The AU Core Responder **SHOULD**:&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;1. Support XML source formats for all AU Core interactions."/>
 <security>
-<description value="See the [Security and Privacy](security.html) page for AU Core security requirements.."/>
+<description value="See the [Security and Privacy](security.html) page for AU Core security requirements."/>
 </security><!-- ALLERGYINTOLERANCE :: DONE -->
 <resource>
 <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
@@ -3116,7 +3116,7 @@
 <name value="category"/>
 <definition value="http://hl7.org/fhir/SearchParameter/Condition-category"/>
 <type value="token"/>
-<documentation value="The category of the condition"/>
+<documentation value="The requester **SHALL** provide at least a code value and **MAY** provide both the system and code values.&#xa;&#xa;The responder **SHALL** support both."/>
 </searchParam>
 <searchParam>
 <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
@@ -3134,7 +3134,7 @@
 <name value="code"/>
 <definition value="http://hl7.org/fhir/SearchParameter/clinical-code"/>
 <type value="token"/>
-<documentation value="The requester **SHALL** provide at least a code value and **MAY** provide both the system and code values.&#xA;&#xA;The responder **SHALL** support both."/>
+<documentation value="The requester **SHALL** provide at least a code value and **MAY** provide both the system and code values.&#xA;&#xA;The responder **SHALL** support both.&#xa;&#xa;The requester **SHOULD** support `multipleOr`.&#xa;&#xa;The responder **SHOULD** support `multipleOr`."/>
 </searchParam>
 <searchParam>
 <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
@@ -3143,7 +3143,7 @@
 <name value="onset-date"/>
 <definition value="http://hl7.org/fhir/SearchParameter/Condition-onset-date"/>
 <type value="date"/>
-<documentation value="A requester **SHALL** provide a value precise to the *second + time offset*.&#xA;&#xA;A responder **SHALL** support a value precise to the *second + time offset*. &#xA;&#xA;The requester **SHALL** support these search comparators `gt`, `lt`, `ge`, `le`.&#xA;&#xA;The responder **SHALL** support these search comparators `gt`, `lt`, `ge`, `le`."/>
+<documentation value="A requester **SHALL** provide a value precise to the *second + time offset*.&#xA;&#xA;A responder **SHALL** support a value precise to the *second + time offset*. &#xA;&#xA;The requester **SHALL** support these search comparators `gt`, `lt`, `ge`, `le`.&#xA;&#xA;The responder **SHALL** support these search comparators `gt`, `lt`, `ge`, `le`.&#xa;&#xa;The requester **SHOULD** support `multipleAnd`.&#xa;&#xa;The responder **SHOULD** support `multipleAnd`."/>
 </searchParam>
 <searchParam>
 <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
@@ -3275,7 +3275,7 @@
 <name value="date"/>
 <definition value="http://hl7.org/fhir/SearchParameter/clinical-date"/>
 <type value="date"/>
-<documentation value="A requester **SHALL** provide a value precise to the *second + time offset*.&#xA;&#xA;A responder **SHALL** support a value precise to the *second + time offset*. &#xA;&#xA;The requester **SHALL** support these search comparators `gt`, `lt`, `ge`, `le`.&#xA;&#xA;The responder **SHALL** support these search comparators `gt`, `lt`, `ge`, `le`."/>
+<documentation value="A requester **SHALL** provide a value precise to the *second + time offset*.&#xA;&#xA;A responder **SHALL** support a value precise to the *second + time offset*. &#xA;&#xA;The requester **SHALL** support these search comparators `gt`, `lt`, `ge`, `le`.&#xA;&#xA;The responder **SHALL** support these search comparators `gt`, `lt`, `ge`, `le`.&#xa;&#xa;The requester **SHOULD** support `multipleAnd`.&#xa;&#xa;The responder **SHOULD** support `multipleAnd`."/>
 </searchParam>
 <searchParam>
 <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
@@ -3293,7 +3293,7 @@
 <name value="status"/>
 <definition value="http://hl7.org/fhir/SearchParameter/DocumentReference-status"/>
 <type value="token"/>
-<documentation value="The requester **SHALL** provide at least a code value and **MAY** provide both the system and code values.&#xA;&#xA;The responder **SHALL** support both."/>
+<documentation value="The requester **SHALL** provide at least a code value and **MAY** provide both the system and code values.&#xA;&#xA;The responder **SHALL** support both.&#xa;&#xa;The requester **SHOULD** support `multipleOr`.&#xa;&#xa;The responder **SHOULD** support `multipleOr`."/>
 </searchParam>
 <searchParam>
 <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
@@ -3405,7 +3405,7 @@
 <name value="date"/>
 <definition value="http://hl7.org/fhir/SearchParameter/clinical-date"/>
 <type value="date"/>
-<documentation value="A requester **SHALL** provide a value precise to the *second + time offset*.&#xA;&#xA;A responder **SHALL** support a value precise to the *second + time offset*. &#xA;&#xA;The requester **SHALL** support these search comparators `gt`, `lt`, `ge`, `le`.&#xA;&#xA;The responder **SHALL** support these search comparators `gt`, `lt`, `ge`, `le`."/>
+<documentation value="A requester **SHALL** provide a value precise to the *second + time offset*.&#xA;&#xA;A responder **SHALL** support a value precise to the *second + time offset*. &#xA;&#xA;The requester **SHALL** support these search comparators `gt`, `lt`, `ge`, `le`.&#xA;&#xA;The responder **SHALL** support these search comparators `gt`, `lt`, `ge`, `le`.&#xa;&#xa;The requester **SHOULD** support `multipleAnd`.&#xa;&#xa;The responder **SHOULD** support `multipleAnd`."/>
 </searchParam>
 <searchParam>
 <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
@@ -3721,7 +3721,7 @@
 <name value="authoredon"/>
 <definition value="http://hl7.org/fhir/SearchParameter/MedicationRequest-authoredon"/>
 <type value="date"/>
-<documentation value="A requester **SHALL** provide a value precise to the *second + time offset*.&#xA;&#xA;A responder **SHALL** support a value precise to the *second + time offset*. &#xA;&#xA;The requester **SHALL** support these search comparators `gt`, `lt`, `ge`, `le`.&#xA;&#xA;The responder **SHALL** support these search comparators `gt`, `lt`, `ge`, `le`."/>
+<documentation value="A requester **SHALL** provide a value precise to the *second + time offset*.&#xA;&#xA;A responder **SHALL** support a value precise to the *second + time offset*. &#xA;&#xA;The requester **SHALL** support these search comparators `gt`, `lt`, `ge`, `le`.&#xA;&#xA;The responder **SHALL** support these search comparators `gt`, `lt`, `ge`, `le`.&#xa;&#xa;The requester **SHOULD** support `multipleAnd`.&#xa;&#xa;The responder **SHOULD** support `multipleAnd`."/>
 </searchParam>
 <searchParam>
 <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
@@ -3739,7 +3739,7 @@
 <name value="status"/>
 <definition value="http://hl7.org/fhir/SearchParameter/medications-status"/>
 <type value="token"/>
-<documentation value="The requester **SHALL** provide at least a code value and **MAY** provide both the system and code values.&#xA;&#xA;The responder **SHALL** support both."/>
+<documentation value="The requester **SHALL** provide at least a code value and **MAY** provide both the system and code values.&#xA;&#xA;The responder **SHALL** support both.&#xa;&#xa;The requester **SHOULD** support `multipleOr`.&#xa;&#xa;The responder **SHOULD** support `multipleOr`."/>
 </searchParam>
 <searchParam>
 <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
@@ -3941,7 +3941,7 @@
 <name value="code"/>
 <definition value="http://hl7.org/fhir/SearchParameter/clinical-code"/>
 <type value="token"/>
-<documentation value="The requester **SHALL** provide at least a code value and **MAY** provide both the system and code values.&#xA;&#xA;The responder **SHALL** support both."/>
+<documentation value="The requester **SHALL** provide at least a code value and **MAY** provide both the system and code values.&#xA;&#xA;The responder **SHALL** support both.&#xa;&#xa;The requester **SHOULD** support `multipleOr`.&#xa;&#xa;The responder **SHOULD** support `multipleOr`."/>
 </searchParam>
 <searchParam>
 <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
@@ -3950,7 +3950,7 @@
 <name value="date"/>
 <definition value="http://hl7.org/fhir/SearchParameter/clinical-date"/>
 <type value="date"/>
-<documentation value="A requester **SHALL** provide a value precise to the *second + time offset*.&#xA;&#xA;A responder **SHALL** support a value precise to the *second + time offset*. &#xA;&#xA;The requester **SHALL** support these search comparators `gt`, `lt`, `ge`, `le`.&#xA;&#xA;The responder **SHALL** support these search comparators `gt`, `lt`, `ge`, `le`."/>
+<documentation value="A requester **SHALL** provide a value precise to the *second + time offset*.&#xA;&#xA;A responder **SHALL** support a value precise to the *second + time offset*. &#xA;&#xA;The requester **SHALL** support these search comparators `gt`, `lt`, `ge`, `le`.&#xA;&#xA;The responder **SHALL** support these search comparators `gt`, `lt`, `ge`, `le`.&#xa;&#xa;The requester **SHOULD** support `multipleAnd`.&#xa;&#xa;The responder **SHOULD** support `multipleAnd`."/>
 </searchParam>
 <searchParam>
 <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
@@ -3959,7 +3959,7 @@
 <name value="status"/>
 <definition value="http://hl7.org/fhir/SearchParameter/Observation-status"/>
 <type value="token"/>
-<documentation value="The requester **SHALL** provide at least a code value and **MAY** provide both the system and code values.&#xA;&#xA;The responder **SHALL** support both."/>
+<documentation value="The requester **SHALL** provide at least a code value and **MAY** provide both the system and code values.&#xA;&#xA;The responder **SHALL** support both.&#xa;&#xa;The requester **SHOULD** support `multipleOr`.&#xa;&#xa;The responder **SHOULD** support `multipleOr`."/>
 </searchParam>
 <searchParam>
 <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
@@ -4535,7 +4535,7 @@
 <name value="code"/>
 <definition value="http://hl7.org/fhir/SearchParameter/clinical-code"/>
 <type value="token"/>
-<documentation value="The requester **SHALL** provide at least a code value and **MAY** provide both the system and code values.&#xA;&#xA;The responder **SHALL** support both."/>
+<documentation value="The requester **SHALL** provide at least a code value and **MAY** provide both the system and code values.&#xA;&#xA;The responder **SHALL** support both.&#xa;&#xa;The requester **SHOULD** support `multipleOr`.&#xa;&#xa;The responder **SHOULD** support `multipleOr`."/>
 </searchParam>
 <searchParam>
 <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
@@ -4544,7 +4544,7 @@
 <name value="date"/>
 <definition value="http://hl7.org/fhir/SearchParameter/clinical-date"/>
 <type value="date"/>
-<documentation value="A requester **SHALL** provide a value precise to the *second + time offset*.&#xA;&#xA;A responder **SHALL** support a value precise to the *second + time offset*. &#xA;&#xA;The requester **SHALL** support these search comparators `gt`, `lt`, `ge`, `le`.&#xA;&#xA;The responder **SHALL** support these search comparators `gt`, `lt`, `ge`, `le`."/>
+<documentation value="A requester **SHALL** provide a value precise to the *second + time offset*.&#xA;&#xA;A responder **SHALL** support a value precise to the *second + time offset*. &#xA;&#xA;The requester **SHALL** support these search comparators `gt`, `lt`, `ge`, `le`.&#xA;&#xA;The responder **SHALL** support these search comparators `gt`, `lt`, `ge`, `le`.&#xa;&#xa;The requester **SHOULD** support `multipleAnd`.&#xa;&#xa;The responder **SHOULD** support `multipleAnd`."/>
 </searchParam>
 <searchParam>
 <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
@@ -4553,7 +4553,7 @@
 <name value="status"/>
 <definition value="http://hl7.org/fhir/SearchParameter/Procedure-status"/>
 <type value="token"/>
-<documentation value="The requester **SHALL** provide at least a code value and **MAY** provide both the system and code values.&#xA;&#xA;The responder **SHALL** support both."/>
+<documentation value="The requester **SHALL** provide at least a code value and **MAY** provide both the system and code values.&#xA;&#xA;The responder **SHALL** support both.&#xa;&#xa;The requester **SHOULD** support `multipleOr`.&#xa;&#xa;The responder **SHOULD** support `multipleOr`."/>
 </searchParam>
 <searchParam>
 <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">

--- a/input/resources/au-core-responder.xml
+++ b/input/resources/au-core-responder.xml
@@ -1843,6 +1843,8 @@
   <div>
     <p>The requester <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p>
     <p>The responder <strong>SHALL</strong> support both.</p>
+    <p>The requester <strong>SHOULD</strong> support <code>multipleOr</code>.</p>
+    <p>The responder <strong>SHOULD</strong> support <code>multipleOr</code>.</p>
   </div>
 </td>
 </tr>
@@ -1864,6 +1866,8 @@
     </p>
     <p>The responder <strong>SHALL</strong> support these search comparators <code>gt</code>, <code>lt</code>, <code>ge</code>, <code>le</code>.        
     </p>
+    <p>The requester <strong>SHOULD</strong> support <code>multipleAnd</code>.</p>
+    <p>The responder <strong>SHOULD</strong> support <code>multipleAnd</code>.</p>
   </div>
 </td>
 </tr>
@@ -1881,6 +1885,8 @@
   <div>
     <p>The requester <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p>
     <p>The responder <strong>SHALL</strong> support both.</p>
+    <p>The requester <strong>SHOULD</strong> support <code>multipleOr</code>.</p>
+    <p>The responder <strong>SHOULD</strong> support <code>multipleOr</code>.</p>
   </div>
 </td>
 </tr>

--- a/input/resources/au-core-responder.xml
+++ b/input/resources/au-core-responder.xml
@@ -3134,7 +3134,7 @@
 <name value="code"/>
 <definition value="http://hl7.org/fhir/SearchParameter/clinical-code"/>
 <type value="token"/>
-<documentation value="The requester **SHALL** provide at least a code value and **MAY** provide both the system and code values.&#xA;&#xA;The responder **SHALL** support both.&#xa;&#xa;The requester **SHOULD** support `multipleOr`.&#xa;&#xa;The responder **SHOULD** support `multipleOr`."/>
+<documentation value="The requester **SHALL** provide at least a code value and **MAY** provide both the system and code values.&#xA;&#xA;The responder **SHALL** support both.&#xa;&#xa;The requester **SHALL** support `multipleOr`.&#xa;&#xa;The responder **SHALL** support `multipleOr`."/>
 </searchParam>
 <searchParam>
 <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
@@ -3293,7 +3293,7 @@
 <name value="status"/>
 <definition value="http://hl7.org/fhir/SearchParameter/DocumentReference-status"/>
 <type value="token"/>
-<documentation value="The requester **SHALL** provide at least a code value and **MAY** provide both the system and code values.&#xA;&#xA;The responder **SHALL** support both.&#xa;&#xa;The requester **SHOULD** support `multipleOr`.&#xa;&#xa;The responder **SHOULD** support `multipleOr`."/>
+<documentation value="The requester **SHALL** provide at least a code value and **MAY** provide both the system and code values.&#xA;&#xA;The responder **SHALL** support both.&#xa;&#xa;The requester **SHALL** support `multipleOr`.&#xa;&#xa;The responder **SHALL** support `multipleOr`."/>
 </searchParam>
 <searchParam>
 <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
@@ -3739,7 +3739,7 @@
 <name value="status"/>
 <definition value="http://hl7.org/fhir/SearchParameter/medications-status"/>
 <type value="token"/>
-<documentation value="The requester **SHALL** provide at least a code value and **MAY** provide both the system and code values.&#xA;&#xA;The responder **SHALL** support both.&#xa;&#xa;The requester **SHOULD** support `multipleOr`.&#xa;&#xa;The responder **SHOULD** support `multipleOr`."/>
+<documentation value="The requester **SHALL** provide at least a code value and **MAY** provide both the system and code values.&#xA;&#xA;The responder **SHALL** support both.&#xa;&#xa;The requester **SHALL** support `multipleOr`.&#xa;&#xa;The responder **SHALL** support `multipleOr`."/>
 </searchParam>
 <searchParam>
 <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
@@ -3941,7 +3941,7 @@
 <name value="code"/>
 <definition value="http://hl7.org/fhir/SearchParameter/clinical-code"/>
 <type value="token"/>
-<documentation value="The requester **SHALL** provide at least a code value and **MAY** provide both the system and code values.&#xA;&#xA;The responder **SHALL** support both.&#xa;&#xa;The requester **SHOULD** support `multipleOr`.&#xa;&#xa;The responder **SHOULD** support `multipleOr`."/>
+<documentation value="The requester **SHALL** provide at least a code value and **MAY** provide both the system and code values.&#xA;&#xA;The responder **SHALL** support both.&#xa;&#xa;The requester **SHALL** support `multipleOr`.&#xa;&#xa;The responder **SHALL** support `multipleOr`."/>
 </searchParam>
 <searchParam>
 <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
@@ -3959,7 +3959,7 @@
 <name value="status"/>
 <definition value="http://hl7.org/fhir/SearchParameter/Observation-status"/>
 <type value="token"/>
-<documentation value="The requester **SHALL** provide at least a code value and **MAY** provide both the system and code values.&#xA;&#xA;The responder **SHALL** support both.&#xa;&#xa;The requester **SHOULD** support `multipleOr`.&#xa;&#xa;The responder **SHOULD** support `multipleOr`."/>
+<documentation value="The requester **SHALL** provide at least a code value and **MAY** provide both the system and code values.&#xA;&#xA;The responder **SHALL** support both.&#xa;&#xa;The requester **SHALL** support `multipleOr`.&#xa;&#xa;The responder **SHALL** support `multipleOr`."/>
 </searchParam>
 <searchParam>
 <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
@@ -4535,7 +4535,7 @@
 <name value="code"/>
 <definition value="http://hl7.org/fhir/SearchParameter/clinical-code"/>
 <type value="token"/>
-<documentation value="The requester **SHALL** provide at least a code value and **MAY** provide both the system and code values.&#xA;&#xA;The responder **SHALL** support both.&#xa;&#xa;The requester **SHOULD** support `multipleOr`.&#xa;&#xa;The responder **SHOULD** support `multipleOr`."/>
+<documentation value="The requester **SHALL** provide at least a code value and **MAY** provide both the system and code values.&#xA;&#xA;The responder **SHALL** support both.&#xa;&#xa;The requester **SHALL** support `multipleOr`.&#xa;&#xa;The responder **SHALL** support `multipleOr`."/>
 </searchParam>
 <searchParam>
 <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
@@ -4553,7 +4553,7 @@
 <name value="status"/>
 <definition value="http://hl7.org/fhir/SearchParameter/Procedure-status"/>
 <type value="token"/>
-<documentation value="The requester **SHALL** provide at least a code value and **MAY** provide both the system and code values.&#xA;&#xA;The responder **SHALL** support both.&#xa;&#xa;The requester **SHOULD** support `multipleOr`.&#xa;&#xa;The responder **SHOULD** support `multipleOr`."/>
+<documentation value="The requester **SHALL** provide at least a code value and **MAY** provide both the system and code values.&#xA;&#xA;The responder **SHALL** support both.&#xa;&#xa;The requester **SHALL** support `multipleOr`.&#xa;&#xa;The responder **SHALL** support `multipleOr`."/>
 </searchParam>
 <searchParam>
 <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">

--- a/input/resources/au-core-responder.xml
+++ b/input/resources/au-core-responder.xml
@@ -2899,7 +2899,7 @@
 <mode value="server"/>
 <documentation value="The AU Core Responder **SHALL**:&#xA;1. Support the AU Core Patient resource profile.&#xA;1. Support at least one additional resource profile from the list of AU Core Profiles.&#xA;1. Implement the RESTful behavior according to the FHIR specification.&#xA;1. Return the following response classes:&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;   - (Status 400): invalid parameter&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;   - (Status 401/4xx): unauthorized request&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;   - (Status 403): insufficient scope&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;   - (Status 404): unknown resource&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;1. Support JSON source formats for all AU Core interactions.&#xA;1. Declare a CapabilityStatement identifying the list of profiles, operations, and search parameters supported.&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;The AU Core Responder **SHOULD**:&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;&#xA;1. Support XML source formats for all AU Core interactions."/>
 <security>
-<description value="TBD requirements and recommendations."/>
+<description value="See the [Security and Privacy](security.html) page for AU Core security requirements.."/>
 </security><!-- ALLERGYINTOLERANCE :: DONE -->
 <resource>
 <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">

--- a/input/resources/au-core-responder.xml
+++ b/input/resources/au-core-responder.xml
@@ -717,8 +717,8 @@
   <div>
     <p>The requester <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p>
     <p>The responder <strong>SHALL</strong> support both.</p>
-    <p>The requester <strong>SHOULD</strong> support <code>multipleOr</code>.</p>
-    <p>The responder <strong>SHOULD</strong> support <code>multipleOr</code>.</p>
+    <p>The requester <strong>SHALL</strong> support <code>multipleOr</code>.</p>
+    <p>The responder <strong>SHALL</strong> support <code>multipleOr</code>.</p>
   </div>
 </td>
 </tr>
@@ -988,8 +988,8 @@
     <div>
       <p>The requester <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p>
       <p>The responder <strong>SHALL</strong> support both.</p>
-      <p>The requester <strong>SHOULD</strong> support <code>multipleOr</code>.</p>
-      <p>The responder <strong>SHOULD</strong> support <code>multipleOr</code>.</p>
+      <p>The requester <strong>SHALL</strong> support <code>multipleOr</code>.</p>
+      <p>The responder <strong>SHALL</strong> support <code>multipleOr</code>.</p>
     </div>
   </td>
 </tr>
@@ -1636,8 +1636,8 @@
   <div>
     <p>The requester <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p>
     <p>The responder <strong>SHALL</strong> support both.</p>
-    <p>The requester <strong>SHOULD</strong> support <code>multipleOr</code>.</p>
-    <p>The responder <strong>SHOULD</strong> support <code>multipleOr</code>.</p>
+    <p>The requester <strong>SHALL</strong> support <code>multipleOr</code>.</p>
+    <p>The responder <strong>SHALL</strong> support <code>multipleOr</code>.</p>
   </div>
 </td>
 </tr>
@@ -1843,8 +1843,8 @@
   <div>
     <p>The requester <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p>
     <p>The responder <strong>SHALL</strong> support both.</p>
-    <p>The requester <strong>SHOULD</strong> support <code>multipleOr</code>.</p>
-    <p>The responder <strong>SHOULD</strong> support <code>multipleOr</code>.</p>
+    <p>The requester <strong>SHALL</strong> support <code>multipleOr</code>.</p>
+    <p>The responder <strong>SHALL</strong> support <code>multipleOr</code>.</p>
   </div>
 </td>
 </tr>
@@ -1885,8 +1885,8 @@
   <div>
     <p>The requester <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p>
     <p>The responder <strong>SHALL</strong> support both.</p>
-    <p>The requester <strong>SHOULD</strong> support <code>multipleOr</code>.</p>
-    <p>The responder <strong>SHOULD</strong> support <code>multipleOr</code>.</p>
+    <p>The requester <strong>SHALL</strong> support <code>multipleOr</code>.</p>
+    <p>The responder <strong>SHALL</strong> support <code>multipleOr</code>.</p>
   </div>
 </td>
 </tr>
@@ -2756,8 +2756,8 @@
   <div>
     <p>The requester <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p>
     <p>The responder <strong>SHALL</strong> support both.</p>
-    <p>The requester <strong>SHOULD</strong> support <code>multipleOr</code>.</p>
-    <p>The responder <strong>SHOULD</strong> support <code>multipleOr</code>.</p>
+    <p>The requester <strong>SHALL</strong> support <code>multipleOr</code>.</p>
+    <p>The responder <strong>SHALL</strong> support <code>multipleOr</code>.</p>
   </div>
 </td>
 </tr>
@@ -2796,8 +2796,8 @@
   <div>
     <p>The requester <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p>
     <p>The responder <strong>SHALL</strong> support both.</p>
-    <p>The requester <strong>SHOULD</strong> support <code>multipleOr</code>.</p>
-    <p>The responder <strong>SHOULD</strong> support <code>multipleOr</code>.</p>
+    <p>The requester <strong>SHALL</strong> support <code>multipleOr</code>.</p>
+    <p>The responder <strong>SHALL</strong> support <code>multipleOr</code>.</p>
   </div>
 </td>
 </tr>


### PR DESCRIPTION
This PR includes the following:
- updates the narrative html to include the missing multipleAnd & multipleOr requirements that are visible on the Profile Notes pages but not in the narrative of capability statements
- updates CapabilityStatement.rest.security.description to match what is in the narrative
- updates the documentation element for search parameters in the CapabilityStatements to include multipleAnd & multipleOr requirements