### PR TITLE
Fix for FHIR-46398: changed smart app launch dependency to 2.1.0

### DIFF
--- a/input/ig.xml
+++ b/input/ig.xml
@@ -40,7 +40,7 @@
 	<dependsOn>
 		<uri value="http://hl7.org/fhir/smart-app-launch/ImplementationGuide/hl7.fhir.uv.smart-app-launch"/>
 		<packageId value="hl7.fhir.uv.smart-app-launch"/>
-		<version value="current"/>
+		<version value="2.1.0"/>
 	</dependsOn>
 	<dependsOn>
 		<uri value="http://hl7.org/fhir/uv/ipa/ImplementationGuide/hl7.fhir.uv.ipa"/>

--- a/input/pagecontent/changes.md
+++ b/input/pagecontent/changes.md
@@ -6,7 +6,7 @@
 This change log documents the significant updates and resolutions implemented from version 0.3.0-ballot to the upcoming August ballot.
 
 #### Changes in this version
-
+- dependency to Smart App Launch changed to 2.1.0 instead of latest (2.2.0) due to missing dependency issue that causes failure to load in NPM Package registry [FHIR-46398](https://jira.hl7.org/browse/FHIR-46398)
 - FHIR Obligations, Actors, and Capabilities:
   - changed the default obligation behaviour in AU Core for Responders from 'be capable of populate' to 'populate if known' [FHIR-45231](https://jira.hl7.org/browse/FHIR-45231), [FHIR-45195](https://jira.hl7.org/browse/FHIR-45195), [FHIR-45163](https://jira.hl7.org/browse/FHIR-45163), [FHIR-45095](https://jira.hl7.org/browse/FHIR-45095), [FHIR-45073](https://jira.hl7.org/browse/FHIR-45073)
   - introduced FHIR Obligations & ActorDefinitions to clarify system actors and associated obligations [FHIR-45231](https://jira.hl7.org/browse/FHIR-45231), [FHIR-45195](https://jira.hl7.org/browse/FHIR-45195), [FHIR-45163](https://jira.hl7.org/browse/FHIR-45163), [FHIR-45073](https://jira.hl7.org/browse/FHIR-45073)

--- a/input/resources/au-core-requester.xml
+++ b/input/resources/au-core-requester.xml
@@ -2845,7 +2845,7 @@
 <valueCode value="SHALL"/>
 </extension>
 </implementationGuide>
-<implementationGuide value="http://hl7.org/fhir/smart-app-launch/ImplementationGuide/hl7.fhir.uv.smart-app-launch|2.2.0">
+<implementationGuide value="http://hl7.org/fhir/smart-app-launch/ImplementationGuide/hl7.fhir.uv.smart-app-launch|2.1.0">
 <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
 <valueCode value="SHOULD"/>
 </extension>

--- a/input/resources/au-core-responder.xml
+++ b/input/resources/au-core-responder.xml
@@ -2865,7 +2865,7 @@
 <valueCode value="SHALL"/>
 </extension>
 </implementationGuide>
-<implementationGuide value="http://hl7.org/fhir/smart-app-launch/ImplementationGuide/hl7.fhir.uv.smart-app-launch|2.2.0">
+<implementationGuide value="http://hl7.org/fhir/smart-app-launch/ImplementationGuide/hl7.fhir.uv.smart-app-launch|2.1.0">
 <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
 <valueCode value="SHOULD"/>
 </extension>


### PR DESCRIPTION
Fix for https://jira.hl7.org/browse/FHIR-46398, changed smart app launch dependency to 2.1.0