### PR TITLE
AU Core invariants: allow data absent reason (FHIR-46419, FHIR-46417, FHIR-46407, FHIR-46406)

### DIFF
--- a/input/pagecontent/changes.md
+++ b/input/pagecontent/changes.md
@@ -46,7 +46,7 @@ This change log documents the significant updates and resolutions implemented fr
   - removed Must Support from MedicationRequest.substitution, MedicationRequest.substitution.allowed[x] [FHIR-45088](https://jira.hl7.org/browse/FHIR-45088)
   - added Must Support to MedicationRequest.reasonReference [FHIR-45090](https://jira.hl7.org/browse/FHIR-45090)
   - support for AMT codes and PBS Item Codes in MedicationRequest.medicationCodeableConcept changed to define slicing in AU Core (no longer inherited from AU Base as per [FHIR-44821](https://jira.hl7.org/browse/FHIR-44821)). Slicing discriminator changed from slicing by value:system to slicing by value set and the binding strength has been corrected to required. [FHIR-46391](https://jira.hl7.org/browse/FHIR-46391)
-  - updated invariant au-core-medreq-03 to allow for a Data Absent Reason extension in order to meet AU Core Missing Data and Suppressed Data requirements [FHIR-46417](https://jira.hl7.org/browse/FHIR-46417)
+  - updated invariant au-core-medreq-03 to allow for a Data Absent Reason extension in order to meet AU Core Missing Data and Suppressed Data requirements, and changed the length check from >= 10 to >= 8 to match the precision required by core FHIR invariants for date precision to the day [FHIR-46417](https://jira.hl7.org/browse/FHIR-46417)
 - Made the following changes to AU Core Medication:
   - removal of Must Support from Medication.manufacturer [FHIR-45130](https://jira.hl7.org/browse/FHIR-45130)
   - removed Must Support from Medication.form [FHIR-45221](https://jira.hl7.org/browse/FHIR-45221)
@@ -110,7 +110,8 @@ This change log documents the significant updates and resolutions implemented fr
   - removed Must Support from Observation.encounter [FHIR-45222](https://jira.hl7.org/browse/FHIR-45222)
   - removed Must Support from Observation.performer [FHIR-45223](https://jira.hl7.org/browse/FHIR-45223)
   - removed the fixed value constraint 'final' on Observation.status [FHIR-45120](https://jira.hl7.org/browse/FHIR-45120)
-  - replaced Observation.code patternCodeableConcept constraint of 266918002 |Tobacco smoking consumption| with 1747861000168109 |Smoking status| [FHIR-45124](https://jira.hl7.org/browse/FHIR-45124) 
+  - replaced Observation.code patternCodeableConcept constraint of 266918002 |Tobacco smoking consumption| with 1747861000168109 |Smoking status| [FHIR-45124](https://jira.hl7.org/browse/FHIR-45124)
+  - updated invariant au-core-obs-01 to change the length check from >= 10 to >= 8 to match the precision required by core FHIR invariants for date precision to the day [FHIR-46407](https://jira.hl7.org/browse/FHIR-46407)
 - Removed Must Support from the following elements in AU Core Immunization:
   - Immunization.encounter [FHIR-45218](https://jira.hl7.org/browse/FHIR-45218)
   - Immunization.performer [FHIR-44653](https://jira.hl7.org/browse/FHIR-44653)
@@ -158,9 +159,11 @@ This change log documents the significant updates and resolutions implemented fr
 - Made the following changes to AU Core Diagnostic Result Observation:
   - in Observation.performer replaced RelatedPerson with AU Base RelatedPerson [FHIR-45228](https://jira.hl7.org/browse/FHIR-45228)
   - removed the required binding to ObservationStatus Result Available value set from Observation.status [FHIR-45125](https://jira.hl7.org/browse/FHIR-45125)
+  - updated invariant au-core-obs-01 to change the length check from >= 10 to >= 8 to match the precision required by core FHIR invariants for date precision to the day [FHIR-46407](https://jira.hl7.org/browse/FHIR-46407)
 - Made the following changes to AU Core Pathology Result Observation:
   - in Observation.performer replaced RelatedPerson with AU Base RelatedPerson [FHIR-45228](https://jira.hl7.org/browse/FHIR-45228)
-    - removed the required binding to ObservationStatus Result Available value set from Observation.status [FHIR-45125](https://jira.hl7.org/browse/FHIR-45125)
+  - removed the required binding to ObservationStatus Result Available value set from Observation.status [FHIR-45125](https://jira.hl7.org/browse/FHIR-45125)
+  - updated invariant au-core-obs-01 to change the length check from >= 10 to >= 8 to match the precision required by core FHIR invariants for date precision to the day [FHIR-46407](https://jira.hl7.org/browse/FHIR-46407)
 - Made the following changes in AU Core Requester CapabilityStatement:
   - removed reference to Bulk Data Access implementation guide [FHIR-45113](https://jira.hl7.org/browse/FHIR-45113)
   - corrected the Observation combined search parameter 'patient+category+status' from SHALL to SHOULD [FHIR-45390](https://jira.hl7.org/browse/FHIR-45390)

--- a/input/pagecontent/changes.md
+++ b/input/pagecontent/changes.md
@@ -67,6 +67,7 @@ This change log documents the significant updates and resolutions implemented fr
   - added Must Support on Patient.name.text [FHIR-44818](https://jira.hl7.org/browse/FHIR-44818)
   - added Must Support on Patient.name.family [FHIR-44818](https://jira.hl7.org/browse/FHIR-44818)
   - added Must Support on Patient.name.given [FHIR-44818](https://jira.hl7.org/browse/FHIR-44818)
+ - updated invariants au-core-pat-01, au-core-pat-02, and au-core-pat-04 to allow for a Data Absent Reason extension in order to meet AU Core Missing Data and Suppressed Data requirements [FHIR-46406](https://jira.hl7.org/browse/FHIR-46406)
 - Made the following changes to AU Core Practitioner:
   - removed Must Support from Practitioner.communication [FHIR-44588](https://jira.hl7.org/browse/FHIR-44588)
   - removed Must Support from Practitioner.qualification, Practitioner.qualification.identifier, Practitioner.qualification.code, Practitioner.qualification.period, Practitioner.qualification.issuer: [FHIR-45118](https://jira.hl7.org/browse/FHIR-45118), [FHIR-44587](https://jira.hl7.org/browse/FHIR-44587)

--- a/input/pagecontent/changes.md
+++ b/input/pagecontent/changes.md
@@ -41,10 +41,12 @@ This change log documents the significant updates and resolutions implemented fr
   - removed Must Support from MedicationRequest.identifier [FHIR-45208](https://jira.hl7.org/browse/FHIR-45208)
   - removed Must Support from MedicationRequest.category [FHIR-45207](https://jira.hl7.org/browse/FHIR-45207)
   - removed Must Support from MedicationRequest.note [FHIR-45209](https://jira.hl7.org/browse/FHIR-45209)
-  - removed Must Support from MedicationRequest.dispenseRequest, MedicationRequest.dispenseRequest.validityPeriod, MedicationRequest.dispenseRequest.numberOfRepeatsAllowed, MedicationRequest.dispenseRequest.quantity [FHIR-45088](https://jira.hl7.org/browse/FHIR-45088)
+  - removed Must Support from MedicationRequest.dispenseRequest, MedicationRequest.dispenseRequest.validityPeriod, MedicationRequest.dispenseRequest.numberOfRepeatsAllowed, MedicationRequest.dispenseRequest.quantity 
+  [FHIR-45088](https://jira.hl7.org/browse/FHIR-45088)
   - removed Must Support from MedicationRequest.substitution, MedicationRequest.substitution.allowed[x] [FHIR-45088](https://jira.hl7.org/browse/FHIR-45088)
   - added Must Support to MedicationRequest.reasonReference [FHIR-45090](https://jira.hl7.org/browse/FHIR-45090)
   - support for AMT codes and PBS Item Codes in MedicationRequest.medicationCodeableConcept changed to define slicing in AU Core (no longer inherited from AU Base as per [FHIR-44821](https://jira.hl7.org/browse/FHIR-44821)). Slicing discriminator changed from slicing by value:system to slicing by value set and the binding strength has been corrected to required. [FHIR-46391](https://jira.hl7.org/browse/FHIR-46391)
+  - updated invariant au-core-medreq-03 to allow for a Data Absent Reason extension in order to meet AU Core Missing Data and Suppressed Data requirements [FHIR-46417](https://jira.hl7.org/browse/FHIR-46417)
 - Made the following changes to AU Core Medication:
   - removal of Must Support from Medication.manufacturer [FHIR-45130](https://jira.hl7.org/browse/FHIR-45130)
   - removed Must Support from Medication.form [FHIR-45221](https://jira.hl7.org/browse/FHIR-45221)
@@ -73,7 +75,9 @@ This change log documents the significant updates and resolutions implemented fr
   - added Must Support on Practitioner.name.family [FHIR-44819](https://jira.hl7.org/browse/FHIR-44819)
   - added Must Support on Practitioner.name.given [FHIR-44819](https://jira.hl7.org/browse/FHIR-44819)
   - replaced constraint _au-core-prac-01: At least text or family name shall be present_ with making Practitioner.name.family mandatory (1..1) [FHIR-44819](https://jira.hl7.org/browse/FHIR-44819)
-- Removed Must Support from PractitionerRole.location in AU Core PractitionerRole [FHIR-43841](https://jira.hl7.org/browse/FHIR-43841).
+- Made the following changes to AU Core PractitionerRole:
+  - removed Must Support from PractitionerRole.location [FHIR-43841](https://jira.hl7.org/browse/FHIR-43841)
+  - updated invariant au-core-prarol-01 to allow for a Data Absent Reason extension in order to meet AU Core Missing Data and Suppressed Data requirements [FHIR-46419](https://jira.hl7.org/browse/FHIR-46419)
 - Made the following changes to AU Core Procedure:
   - removed Must Support from Procedure.statusReason [FHIR-45013](https://jira.hl7.org/browse/FHIR-45013)
   - removed Must Support from Procedure.category [FHIR-45014](https://jira.hl7.org/browse/FHIR-45014)

--- a/input/pagecontent/changes.md
+++ b/input/pagecontent/changes.md
@@ -46,7 +46,7 @@ This change log documents the significant updates and resolutions implemented fr
   - removed Must Support from MedicationRequest.substitution, MedicationRequest.substitution.allowed[x] [FHIR-45088](https://jira.hl7.org/browse/FHIR-45088)
   - added Must Support to MedicationRequest.reasonReference [FHIR-45090](https://jira.hl7.org/browse/FHIR-45090)
   - support for AMT codes and PBS Item Codes in MedicationRequest.medicationCodeableConcept changed to define slicing in AU Core (no longer inherited from AU Base as per [FHIR-44821](https://jira.hl7.org/browse/FHIR-44821)). Slicing discriminator changed from slicing by value:system to slicing by value set and the binding strength has been corrected to required. [FHIR-46391](https://jira.hl7.org/browse/FHIR-46391)
-  - updated invariant au-core-medreq-03 to allow for a Data Absent Reason extension in order to meet AU Core Missing Data and Suppressed Data requirements, and changed the length check from >= 10 to >= 8 to match the precision required by core FHIR invariants for date precision to the day [FHIR-46417](https://jira.hl7.org/browse/FHIR-46417)
+  - updated invariant au-core-medreq-03 to allow for a Data Absent Reason extension in order to meet AU Core Missing Data and Suppressed Data requirements, and changed the length check from >= 10 to >= 8 to match required precision to the day [FHIR-46417](https://jira.hl7.org/browse/FHIR-46417)
 - Made the following changes to AU Core Medication:
   - removal of Must Support from Medication.manufacturer [FHIR-45130](https://jira.hl7.org/browse/FHIR-45130)
   - removed Must Support from Medication.form [FHIR-45221](https://jira.hl7.org/browse/FHIR-45221)
@@ -111,7 +111,7 @@ This change log documents the significant updates and resolutions implemented fr
   - removed Must Support from Observation.performer [FHIR-45223](https://jira.hl7.org/browse/FHIR-45223)
   - removed the fixed value constraint 'final' on Observation.status [FHIR-45120](https://jira.hl7.org/browse/FHIR-45120)
   - replaced Observation.code patternCodeableConcept constraint of 266918002 |Tobacco smoking consumption| with 1747861000168109 |Smoking status| [FHIR-45124](https://jira.hl7.org/browse/FHIR-45124)
-  - updated invariant au-core-obs-01 to change the length check from >= 10 to >= 8 to match the precision required by core FHIR invariants for date precision to the day [FHIR-46407](https://jira.hl7.org/browse/FHIR-46407)
+  - updated invariant au-core-obs-01 to change the length check from >= 10 to >= 8 to match required precision to the day [FHIR-46407](https://jira.hl7.org/browse/FHIR-46407)
 - Removed Must Support from the following elements in AU Core Immunization:
   - Immunization.encounter [FHIR-45218](https://jira.hl7.org/browse/FHIR-45218)
   - Immunization.performer [FHIR-44653](https://jira.hl7.org/browse/FHIR-44653)
@@ -159,11 +159,11 @@ This change log documents the significant updates and resolutions implemented fr
 - Made the following changes to AU Core Diagnostic Result Observation:
   - in Observation.performer replaced RelatedPerson with AU Base RelatedPerson [FHIR-45228](https://jira.hl7.org/browse/FHIR-45228)
   - removed the required binding to ObservationStatus Result Available value set from Observation.status [FHIR-45125](https://jira.hl7.org/browse/FHIR-45125)
-  - updated invariant au-core-obs-01 to change the length check from >= 10 to >= 8 to match the precision required by core FHIR invariants for date precision to the day [FHIR-46407](https://jira.hl7.org/browse/FHIR-46407)
+  - updated invariant au-core-obs-01 to change the length check from >= 10 to >= 8 to match required precision to the day [FHIR-46407](https://jira.hl7.org/browse/FHIR-46407)
 - Made the following changes to AU Core Pathology Result Observation:
   - in Observation.performer replaced RelatedPerson with AU Base RelatedPerson [FHIR-45228](https://jira.hl7.org/browse/FHIR-45228)
   - removed the required binding to ObservationStatus Result Available value set from Observation.status [FHIR-45125](https://jira.hl7.org/browse/FHIR-45125)
-  - updated invariant au-core-obs-01 to change the length check from >= 10 to >= 8 to match the precision required by core FHIR invariants for date precision to the day [FHIR-46407](https://jira.hl7.org/browse/FHIR-46407)
+  - updated invariant au-core-obs-01 to change the length check from >= 10 to >= 8 to match required precision to the day [FHIR-46407](https://jira.hl7.org/browse/FHIR-46407)
 - Made the following changes in AU Core Requester CapabilityStatement:
   - removed reference to Bulk Data Access implementation guide [FHIR-45113](https://jira.hl7.org/browse/FHIR-45113)
   - corrected the Observation combined search parameter 'patient+category+status' from SHALL to SHOULD [FHIR-45390](https://jira.hl7.org/browse/FHIR-45390)

--- a/input/resources/au-core-diagnosticresult-path.xml
+++ b/input/resources/au-core-diagnosticresult-path.xml
@@ -161,7 +161,7 @@
         <key value="au-core-obs-01"/>
         <severity value="error"/>
         <human value="Date shall be at least to day"/>
-        <expression value="$this is DateTime implies $this.toString().length() &gt;= 10"/>
+        <expression value="$this is DateTime implies $this.toString().length() &gt;= 8"/>
         <xpath value="f:matches(effectiveDateTime,/\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d([+-][0-2]\d:[0-5]\d|Z)/)"/>
         <source value="http://hl7.org.au/fhir/core/StructureDefinition/au-core-diagnosticresult-path"/>
       </constraint>

--- a/input/resources/au-core-diagnosticresult-path.xml
+++ b/input/resources/au-core-diagnosticresult-path.xml
@@ -161,8 +161,8 @@
         <key value="au-core-obs-01"/>
         <severity value="error"/>
         <human value="Date shall be at least to day"/>
-        <expression value="$this is DateTime implies $this.toString().length() &gt;= 10 or extension('http://hl7.org/fhir/StructureDefinition/data-absent-reason').exists()"/>
-        <xpath value="f:matches(effectiveDateTime,/\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d([+-][0-2]\d:[0-5]\d|Z)/) or exists(f:extension[@url='http://hl7.org/fhir/StructureDefinition/data-absent-reason'])"/>
+        <expression value="$this is DateTime implies $this.toString().length() &gt;= 10"/>
+        <xpath value="f:matches(effectiveDateTime,/\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d([+-][0-2]\d:[0-5]\d|Z)/)"/>
         <source value="http://hl7.org.au/fhir/core/StructureDefinition/au-core-diagnosticresult-path"/>
       </constraint>
       <mustSupport value="true"/>

--- a/input/resources/au-core-diagnosticresult-path.xml
+++ b/input/resources/au-core-diagnosticresult-path.xml
@@ -161,8 +161,8 @@
         <key value="au-core-obs-01"/>
         <severity value="error"/>
         <human value="Date shall be at least to day"/>
-        <expression value="$this is DateTime implies $this.toString().length() &gt;= 10"/>
-        <xpath value="f:matches(effectiveDateTime,/\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d([+-][0-2]\d:[0-5]\d|Z)/)"/>
+        <expression value="$this is DateTime implies $this.toString().length() &gt;= 10 or extension('http://hl7.org/fhir/StructureDefinition/data-absent-reason').exists()"/>
+        <xpath value="f:matches(effectiveDateTime,/\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d([+-][0-2]\d:[0-5]\d|Z)/) or exists(f:extension[@url='http://hl7.org/fhir/StructureDefinition/data-absent-reason'])"/>
         <source value="http://hl7.org.au/fhir/core/StructureDefinition/au-core-diagnosticresult-path"/>
       </constraint>
       <mustSupport value="true"/>

--- a/input/resources/au-core-diagnosticresult.xml
+++ b/input/resources/au-core-diagnosticresult.xml
@@ -158,8 +158,8 @@
         <key value="au-core-obs-01"/>
         <severity value="error"/>
         <human value="Date shall be at least to day"/>
-        <expression value="$this is DateTime implies $this.toString().length() &gt;= 10"/>
-        <xpath value="f:matches(effectiveDateTime,/\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d([+-][0-2]\d:[0-5]\d|Z)/)"/>
+        <expression value="$this is DateTime implies $this.toString().length() &gt;= 10 or extension('http://hl7.org/fhir/StructureDefinition/data-absent-reason').exists()"/>
+        <xpath value="f:matches(effectiveDateTime,/\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d([+-][0-2]\d:[0-5]\d|Z)/) or exists(f:extension[@url='http://hl7.org/fhir/StructureDefinition/data-absent-reason'])"/>
         <source value="http://hl7.org.au/fhir/core/StructureDefinition/au-core-diagnosticresult"/>
       </constraint>
       <mustSupport value="true"/>

--- a/input/resources/au-core-diagnosticresult.xml
+++ b/input/resources/au-core-diagnosticresult.xml
@@ -158,8 +158,8 @@
         <key value="au-core-obs-01"/>
         <severity value="error"/>
         <human value="Date shall be at least to day"/>
-        <expression value="$this is DateTime implies $this.toString().length() &gt;= 10 or extension('http://hl7.org/fhir/StructureDefinition/data-absent-reason').exists()"/>
-        <xpath value="f:matches(effectiveDateTime,/\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d([+-][0-2]\d:[0-5]\d|Z)/) or exists(f:extension[@url='http://hl7.org/fhir/StructureDefinition/data-absent-reason'])"/>
+        <expression value="$this is DateTime implies $this.toString().length() &gt;= 10"/>
+        <xpath value="f:matches(effectiveDateTime,/\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d([+-][0-2]\d:[0-5]\d|Z)/)"/>
         <source value="http://hl7.org.au/fhir/core/StructureDefinition/au-core-diagnosticresult"/>
       </constraint>
       <mustSupport value="true"/>

--- a/input/resources/au-core-diagnosticresult.xml
+++ b/input/resources/au-core-diagnosticresult.xml
@@ -158,7 +158,7 @@
         <key value="au-core-obs-01"/>
         <severity value="error"/>
         <human value="Date shall be at least to day"/>
-        <expression value="$this is DateTime implies $this.toString().length() &gt;= 10"/>
+        <expression value="$this is DateTime implies $this.toString().length() &gt;= 8"/>
         <xpath value="f:matches(effectiveDateTime,/\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d([+-][0-2]\d:[0-5]\d|Z)/)"/>
         <source value="http://hl7.org.au/fhir/core/StructureDefinition/au-core-diagnosticresult"/>
       </constraint>

--- a/input/resources/au-core-medicationrequest.xml
+++ b/input/resources/au-core-medicationrequest.xml
@@ -247,8 +247,8 @@
       <constraint>
         <key value="au-core-medreq-03"/>
         <severity value="error"/>
-        <human value="Date is precise to the day or, if not available, the Data Absent Reason extension shall be present"/>
-        <expression value="(toString().length() &gt;= 10) xor extension('http://hl7.org/fhir/StructureDefinition/data-absent-reason').exists()"/>
+        <human value="Date shall be precise to the day or, if not available, the Data Absent Reason extension shall be present"/>
+        <expression value="(toString().length() &gt;= 8) xor extension('http://hl7.org/fhir/StructureDefinition/data-absent-reason').exists()"/>
         <xpath value="(f:matches(f:effectiveDateTime, /\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d([+-][0-2]\d:[0-5]\d|Z)) and not(exists(f:extension[@url='http://hl7.org/fhir/StructureDefinition/data-absent-reason']))) or (not(f:matches(f:effectiveDateTime, /\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d([+-][0-2]\d:[0-5]\d|Z))) and exists(f:extension[@url='http://hl7.org/fhir/StructureDefinition/data-absent-reason']))"/>
         <source value="http://hl7.org.au/fhir/core/StructureDefinition/au-core-medicationrequest"/>
       </constraint>

--- a/input/resources/au-core-medicationrequest.xml
+++ b/input/resources/au-core-medicationrequest.xml
@@ -248,8 +248,8 @@
         <key value="au-core-medreq-03"/>
         <severity value="error"/>
         <human value="Date shall be at least to day"/>
-        <expression value="toString().length() &gt;= 10"/>
-        <xpath value="f:matches(effectiveDateTime,/\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d([+-][0-2]\d:[0-5]\d|Z)/)"/>
+        <expression value="toString().length() &gt;= 10 or extension('http://hl7.org/fhir/StructureDefinition/data-absent-reason').exists()"/>
+        <xpath value="f:matches(effectiveDateTime,/\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d([+-][0-2]\d:[0-5]\d|Z) or exists(f:extension[@url='http://hl7.org/fhir/StructureDefinition/data-absent-reason'])"/>
         <source value="http://hl7.org.au/fhir/core/StructureDefinition/au-core-medicationrequest"/>
       </constraint>
       <mustSupport value="true"/>

--- a/input/resources/au-core-medicationrequest.xml
+++ b/input/resources/au-core-medicationrequest.xml
@@ -247,9 +247,9 @@
       <constraint>
         <key value="au-core-medreq-03"/>
         <severity value="error"/>
-        <human value="Date shall be at least to day"/>
-        <expression value="toString().length() &gt;= 10 or extension('http://hl7.org/fhir/StructureDefinition/data-absent-reason').exists()"/>
-        <xpath value="f:matches(effectiveDateTime,/\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d([+-][0-2]\d:[0-5]\d|Z) or exists(f:extension[@url='http://hl7.org/fhir/StructureDefinition/data-absent-reason'])"/>
+        <human value="Date is precise to the day or, if not available, the Data Absent Reason extension is present"/>
+        <expression value="(toString().length() &gt;= 10) xor extension('http://hl7.org/fhir/StructureDefinition/data-absent-reason').exists()"/>
+        <xpath value="(f:matches(f:effectiveDateTime, /\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d([+-][0-2]\d:[0-5]\d|Z)) and not(exists(f:extension[@url='http://hl7.org/fhir/StructureDefinition/data-absent-reason']))) or (not(f:matches(f:effectiveDateTime, /\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d([+-][0-2]\d:[0-5]\d|Z))) and exists(f:extension[@url='http://hl7.org/fhir/StructureDefinition/data-absent-reason']))"/>
         <source value="http://hl7.org.au/fhir/core/StructureDefinition/au-core-medicationrequest"/>
       </constraint>
       <mustSupport value="true"/>

--- a/input/resources/au-core-medicationrequest.xml
+++ b/input/resources/au-core-medicationrequest.xml
@@ -247,7 +247,7 @@
       <constraint>
         <key value="au-core-medreq-03"/>
         <severity value="error"/>
-        <human value="Date is precise to the day or, if not available, the Data Absent Reason extension is present"/>
+        <human value="Date is precise to the day or, if not available, the Data Absent Reason extension shall be present"/>
         <expression value="(toString().length() &gt;= 10) xor extension('http://hl7.org/fhir/StructureDefinition/data-absent-reason').exists()"/>
         <xpath value="(f:matches(f:effectiveDateTime, /\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d([+-][0-2]\d:[0-5]\d|Z)) and not(exists(f:extension[@url='http://hl7.org/fhir/StructureDefinition/data-absent-reason']))) or (not(f:matches(f:effectiveDateTime, /\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d([+-][0-2]\d:[0-5]\d|Z))) and exists(f:extension[@url='http://hl7.org/fhir/StructureDefinition/data-absent-reason']))"/>
         <source value="http://hl7.org.au/fhir/core/StructureDefinition/au-core-medicationrequest"/>

--- a/input/resources/au-core-patient.xml
+++ b/input/resources/au-core-patient.xml
@@ -21,16 +21,16 @@
       <constraint>
         <key value="au-core-pat-01"/>
         <severity value="error"/>
-        <human value="At least one patient identifier shall be valid"/>
-        <expression value="identifier.where(system.count() + value.count() &gt;1).exists() or identifier.extension('http://hl7.org/fhir/StructureDefinition/data-absent-reason').exists()"/>
-        <xpath value="exists(f:identifier[f:system and f:value]) or exists(f:identifier/f:extension[@url='http://hl7.org/fhir/StructureDefinition/data-absent-reason'])"/>
+        <human value="At least one patient identifier shall be valid, or if not available, the Data Absent Reason extension shall be present"/>
+        <expression value="(identifier.where(system.count() + value.count() &gt;1)).exists() xor identifier.extension('http://hl7.org/fhir/StructureDefinition/data-absent-reason').exists()"/>
+        <xpath value="(exists(f:identifier/f:system) and exists(f:identifier/f:value)) and not(exists(f:identifier/f:extension[@url='http://hl7.org/fhir/StructureDefinition/data-absent-reason'])) or not(exists(f:identifier/f:system) and exists(f:identifier/f:value)) and exists(f:identifier/f:extension[@url='http://hl7.org/fhir/StructureDefinition/data-absent-reason'])"/>
       </constraint>
       <constraint>
         <key value="au-core-pat-02"/>
         <severity value="error"/>
-        <human value="At least one patient name shall have a family name"/>
-        <expression value="name.family.exists() or name.extension('http://hl7.org/fhir/StructureDefinition/data-absent-reason').exists()"/>
-        <xpath value="exists(f:name/f:family) or exists(f:name/f:extension[@url='http://hl7.org/fhir/StructureDefinition/data-absent-reason'])"/>
+        <human value="At least one patient name shall have a family name, or if not available, the Data Absent Reason extension shall be present"/>
+        <expression value="name.family.exists() xor name.extension('http://hl7.org/fhir/StructureDefinition/data-absent-reason').exists()"/>
+        <xpath value="(exists(f:name/f:family) and not(exists(f:name/f:extension[@url='http://hl7.org/fhir/StructureDefinition/data-absent-reason']))) or (not(exists(f:name/f:family)) and exists(f:name/f:extension[@url='http://hl7.org/fhir/StructureDefinition/data-absent-reason']))"/>
         <source
           value="http://hl7.org.au/fhir/core/StructureDefinition/au-core-patient"
         />
@@ -235,8 +235,8 @@
         <key value="au-core-pat-04"/> 
         <severity value="error"/>
         <human value="At least text, family name, or given name shall be present"/>
-        <expression value="text.exists() or family.exists() or given.exists() or extension('http://hl7.org/fhir/StructureDefinition/data-absent-reason').exists()"/>
-        <xpath value="exists(f:text) or exists(f:family) or exists(f:given) or exists(f:extension[@url='http://hl7.org/fhir/StructureDefinition/data-absent-reason'])"/>
+        <expression value="(text.exists() or family.exists() or given.exists()) xor extension('http://hl7.org/fhir/StructureDefinition/data-absent-reason').exists()"/>
+        <xpath value="(exists(f:text) or exists(f:family) or exists(f:given)) and not (exists(f:text) and exists(f:family) and exists(f:given)) or exists(f:extension[@url='http://hl7.org/fhir/StructureDefinition/data-absent-reason'])"/>
         <source
           value="http://hl7.org.au/fhir/core/StructureDefinition/au-core-patient"
         />

--- a/input/resources/au-core-patient.xml
+++ b/input/resources/au-core-patient.xml
@@ -234,7 +234,7 @@
       <constraint>
         <key value="au-core-pat-04"/> 
         <severity value="error"/>
-        <human value="At least text, family name, or given name shall be present"/>
+        <human value="At least text, family name, or given name shall be present, or if neither is available, the Data Absent Reason extension shall be present"/>
         <expression value="(text.exists() or family.exists() or given.exists()) xor extension('http://hl7.org/fhir/StructureDefinition/data-absent-reason').exists()"/>
         <xpath value="(exists(f:text) or exists(f:family) or exists(f:given)) and not (exists(f:text) and exists(f:family) and exists(f:given)) or exists(f:extension[@url='http://hl7.org/fhir/StructureDefinition/data-absent-reason'])"/>
         <source

--- a/input/resources/au-core-patient.xml
+++ b/input/resources/au-core-patient.xml
@@ -22,17 +22,15 @@
         <key value="au-core-pat-01"/>
         <severity value="error"/>
         <human value="At least one patient identifier shall be valid"/>
-        <expression value="identifier.where(system.count() + value.count() &gt;1).exists()"/>
-        <xpath value="exists(f:identifier/f:system)"/>
-        <source value="http://hl7.org.au/fhir/core/StructureDefinition/au-core-patient"
-        />
+        <expression value="identifier.where(system.count() + value.count() &gt;1).exists() or identifier.extension('http://hl7.org/fhir/StructureDefinition/data-absent-reason').exists()"/>
+        <xpath value="exists(f:identifier[f:system and f:value]) or exists(f:identifier/f:extension[@url='http://hl7.org/fhir/StructureDefinition/data-absent-reason'])"/>
       </constraint>
       <constraint>
         <key value="au-core-pat-02"/>
         <severity value="error"/>
         <human value="At least one patient name shall have a family name"/>
-        <expression value="name.family.exists()"/>
-        <xpath value="exists(f:name/f:family)"/>
+        <expression value="name.family.exists() or name.extension('http://hl7.org/fhir/StructureDefinition/data-absent-reason').exists()"/>
+        <xpath value="exists(f:name/f:family) or exists(f:name/f:extension[@url='http://hl7.org/fhir/StructureDefinition/data-absent-reason'])"/>
         <source
           value="http://hl7.org.au/fhir/core/StructureDefinition/au-core-patient"
         />
@@ -234,13 +232,11 @@
       <comment value="A patient may have multiple names with different uses or applicable periods. At least one name SHOULD be the name the patient is considered to have for administrative and record keeping purposes - family name is used to enable matching against patient records."/>
       <condition value="au-core-pat-02"/>
       <constraint>
-        <key value="au-core-pat-04"/>
+        <key value="au-core-pat-04"/> 
         <severity value="error"/>
-        <human
-          value="At least text, family name, or given name shall be present"/>
-        <expression
-          value="text.exists() or family.exists() or given.exists()"/>
-        <xpath value="exists(f:text) or exists(f:family) or exists(f:given)"/>
+        <human value="At least text, family name, or given name shall be present"/>
+        <expression value="text.exists() or family.exists() or given.exists() or extension('http://hl7.org/fhir/StructureDefinition/data-absent-reason').exists()"/>
+        <xpath value="exists(f:text) or exists(f:family) or exists(f:given) or exists(f:extension[@url='http://hl7.org/fhir/StructureDefinition/data-absent-reason'])"/>
         <source
           value="http://hl7.org.au/fhir/core/StructureDefinition/au-core-patient"
         />

--- a/input/resources/au-core-practitionerrole.xml
+++ b/input/resources/au-core-practitionerrole.xml
@@ -100,7 +100,7 @@
       <constraint>
         <key value="au-core-prarol-01"/>
         <severity value="error"/>
-        <human value="At least a reference, identifier or display shall be present, or, if neither is available, the Data Absent Reason extension is present"/>
+        <human value="At least a reference, identifier or display shall be present, or, if neither is available, the Data Absent Reason extension shall be present"/>
         <expression value="(reference.exists() or identifier.exists() or display.exists()) xor extension('http://hl7.org/fhir/StructureDefinition/data-absent-reason').exists()"/>
         <xpath value="(exists(f:reference) or exists(f:display) or exists(f:identifier)) and not(exists(f:extension[@url='http://hl7.org/fhir/StructureDefinition/data-absent-reason'])) or not(exists(f:reference) or exists(f:display) or exists(f:identifier)) and exists(f:extension[@url='http://hl7.org/fhir/StructureDefinition/data-absent-reason'])"/>
         <source value="http://hl7.org.au/fhir/core/StructureDefinition/au-core-practitionerrole" />

--- a/input/resources/au-core-practitionerrole.xml
+++ b/input/resources/au-core-practitionerrole.xml
@@ -2,7 +2,7 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="au-core-practitionerrole"/>
   <extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
-    <valueInteger value="1"/> 
+    <valueInteger value="1"/>
   </extension>
   <url value="http://hl7.org.au/fhir/core/StructureDefinition/au-core-practitionerrole"/>
   <name value="AUCorePractitionerRole"/>
@@ -94,22 +94,16 @@
       <min value="1"/>
       <type>
         <code value="Reference"/>
-        <targetProfile
-          value="http://hl7.org.au/fhir/core/StructureDefinition/au-core-practitioner"
-        />
+        <targetProfile value="http://hl7.org.au/fhir/core/StructureDefinition/au-core-practitioner" />
       </type>
       <condition value="au-core-prarol-01"/>
       <constraint>
         <key value="au-core-prarol-01"/>
         <severity value="error"/>
-        <human
-          value="At least a reference, identifier or display shall be present"/>
-        <expression
-          value="reference.exists() or identifier.exists() or display.exists()"/>
-        <xpath value="exists(f:reference) or exists(f:display) or exists(f:identifier)"/>
-        <source
-          value="http://hl7.org.au/fhir/core/StructureDefinition/au-core-practitionerrole"
-        />
+        <human value="At least a reference, identifier or display shall be present"/>
+        <expression value="reference.exists() or identifier.exists() or display.exists() or extension('http://hl7.org/fhir/StructureDefinition/data-absent-reason').exists()"/>
+        <xpath value="exists(f:reference) or exists(f:display) or exists(f:identifier) or exists(f:extension[@url='http://hl7.org/fhir/StructureDefinition/data-absent-reason'])"/>
+        <source value="http://hl7.org.au/fhir/core/StructureDefinition/au-core-practitionerrole" />
       </constraint>
       <mustSupport value="true"/>
     </element>
@@ -133,9 +127,7 @@
       <path value="PractitionerRole.organization"/>
       <type>
         <code value="Reference"/>
-        <targetProfile
-          value="http://hl7.org.au/fhir/core/StructureDefinition/au-core-organization"
-        />
+        <targetProfile value="http://hl7.org.au/fhir/core/StructureDefinition/au-core-organization" />
       </type>
       <mustSupport value="true"/>
     </element>

--- a/input/resources/au-core-practitionerrole.xml
+++ b/input/resources/au-core-practitionerrole.xml
@@ -100,9 +100,9 @@
       <constraint>
         <key value="au-core-prarol-01"/>
         <severity value="error"/>
-        <human value="At least a reference, identifier or display shall be present"/>
-        <expression value="reference.exists() or identifier.exists() or display.exists() or extension('http://hl7.org/fhir/StructureDefinition/data-absent-reason').exists()"/>
-        <xpath value="exists(f:reference) or exists(f:display) or exists(f:identifier) or exists(f:extension[@url='http://hl7.org/fhir/StructureDefinition/data-absent-reason'])"/>
+        <human value="At least a reference, identifier or display shall be present, or, if neither is available, the Data Absent Reason extension is present"/>
+        <expression value="(reference.exists() or identifier.exists() or display.exists()) xor extension('http://hl7.org/fhir/StructureDefinition/data-absent-reason').exists()"/>
+        <xpath value="(exists(f:reference) or exists(f:display) or exists(f:identifier)) and not(exists(f:extension[@url='http://hl7.org/fhir/StructureDefinition/data-absent-reason'])) or not(exists(f:reference) or exists(f:display) or exists(f:identifier)) and exists(f:extension[@url='http://hl7.org/fhir/StructureDefinition/data-absent-reason'])"/>
         <source value="http://hl7.org.au/fhir/core/StructureDefinition/au-core-practitionerrole" />
       </constraint>
       <mustSupport value="true"/>

--- a/input/resources/au-core-smokingstatus.xml
+++ b/input/resources/au-core-smokingstatus.xml
@@ -198,8 +198,8 @@
         <key value="au-core-obs-01"/>
         <severity value="error"/>
         <human value="Date shall be at least to day"/>
-        <expression value="$this is DateTime implies $this.toString().length() &gt;= 10 or extension('http://hl7.org/fhir/StructureDefinition/data-absent-reason').exists()"/>
-        <xpath value="f:matches(effectiveDateTime,/\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d([+-][0-2]\d:[0-5]\d|Z)/) or exists(f:extension[@url='http://hl7.org/fhir/StructureDefinition/data-absent-reason'])"/>
+        <expression value="$this is DateTime implies $this.toString().length() &gt;= 10"/>
+        <xpath value="f:matches(effectiveDateTime,/\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d([+-][0-2]\d:[0-5]\d|Z)/)"/>
         <source value="http://hl7.org.au/fhir/core/StructureDefinition/au-core-smokingstatus"/>
       </constraint>
       <mustSupport value="true"/>

--- a/input/resources/au-core-smokingstatus.xml
+++ b/input/resources/au-core-smokingstatus.xml
@@ -198,8 +198,8 @@
         <key value="au-core-obs-01"/>
         <severity value="error"/>
         <human value="Date shall be at least to day"/>
-        <expression value="$this is DateTime implies $this.toString().length() &gt;= 10"/>
-        <xpath value="f:matches(effectiveDateTime,/\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d([+-][0-2]\d:[0-5]\d|Z)/)"/>
+        <expression value="$this is DateTime implies $this.toString().length() &gt;= 10 or extension('http://hl7.org/fhir/StructureDefinition/data-absent-reason').exists()"/>
+        <xpath value="f:matches(effectiveDateTime,/\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d([+-][0-2]\d:[0-5]\d|Z)/) or exists(f:extension[@url='http://hl7.org/fhir/StructureDefinition/data-absent-reason'])"/>
         <source value="http://hl7.org.au/fhir/core/StructureDefinition/au-core-smokingstatus"/>
       </constraint>
       <mustSupport value="true"/>

--- a/input/resources/au-core-smokingstatus.xml
+++ b/input/resources/au-core-smokingstatus.xml
@@ -198,7 +198,7 @@
         <key value="au-core-obs-01"/>
         <severity value="error"/>
         <human value="Date shall be at least to day"/>
-        <expression value="$this is DateTime implies $this.toString().length() &gt;= 10"/>
+        <expression value="$this is DateTime implies $this.toString().length() &gt;= 8"/>
         <xpath value="f:matches(effectiveDateTime,/\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d([+-][0-2]\d:[0-5]\d|Z)/)"/>
         <source value="http://hl7.org.au/fhir/core/StructureDefinition/au-core-smokingstatus"/>
       </constraint>


### PR DESCRIPTION
This PR provides fixes for: 
- [FHIR-46419](https://jira.hl7.org/browse/FHIR-46419) PractitionerRole with data-absent-reason extension for practitioner has unexpected validation error
- [FHIR-46417](https://jira.hl7.org/browse/FHIR-46417) AU Core MedicationRequest missing data extension on authoredOn causes unexpected validation error
- [FHIR-46407](https://jira.hl7.org/browse/FHIR-46407) data-absent-reason extension on Observation effectiveDateTime element cause constraint rule validation errors
- [FHIR-46406](https://jira.hl7.org/browse/FHIR-46406) data-absent-reason extension on Patient identifier and name elements cause constraint rule validation errors

Changes to update AU Core invariants to allow data absent reason:
- AU Core Patient: au-core-pat-01, au-core-pat-02, au-core-pat-04
- AU Core PractitionerRole: au-core-prarol-01
- AU Core MedicationRequest: au-core-medreq-03
- Observation profiles:
  - AU Core Pathology Result Observation, AU Core Diagnostic Result Observation, AU Core Smoking Status: au-core-obs-01

Noting that AU Core vital signs profiles inherit from core a constraint vs-1: "if Observation.effective[x] is dateTime and has a value then that value shall be precise to the day" which does not allow data absent reason and cannot be overwritten in AU Core. (It also makes the AU Core constraint au-core-obs-01 on vital signs profile superfluous (I will raise a TC for consideration to remove it from AU Core).)