### PR TITLE
Fix duplicate entry on IPS Additional Profiles

### DIFF
--- a/input/pagecontent/comparison.md
+++ b/input/pagecontent/comparison.md
@@ -341,7 +341,7 @@ This version of AU Core has no equivalent profile for the following IPS profiles
 - Composition (IPS)
 - Device (IPS)
 - Device - performer, observer
-- Device - performer, observer
+- Device Use Statement (IPS)
 - DiagnosticReport (IPS)
 - Imaging Study (IPS)
 - Media observation (Results: laboratory, media)


### PR DESCRIPTION
Remove duplicate entry of 'Device - performer, observer', replace with 'Device Use Statement (IPS).

https://github.com/orgs/hl7au/projects/8/views/1?pane=issue&itemId=79393106