### PR TITLE
Add missing resource support to AU Core Capability Statements (FHIR-46546)

### DIFF
--- a/input/pagecontent/changes.md
+++ b/input/pagecontent/changes.md
@@ -180,7 +180,7 @@ This change log documents the significant updates and resolutions implemented fr
   - corrected the Observation combined search parameter 'patient+category+status' from SHALL to SHOULD [FHIR-45390](https://jira.hl7.org/browse/FHIR-45390)
   - corrected narrative of Location identifier parameter requester requirements on providing both the system and code values from SHOULD to MAY [FHIR-46209](https://jira.hl7.org/browse/FHIR-46209)
   - replaced security and authorization requirements with pointer to Security and Privacy page [FHIR-46067](https://jira.hl7.org/browse/FHIR-46067)
-  - added missing entry for DocumentReference and RelatedPerson resources [FHIR-46546](https://jira.hl7.org/browse/FHIR-46546)
+  - added missing entries for DocumentReference and RelatedPerson resources [FHIR-46546](https://jira.hl7.org/browse/FHIR-46546)
 - Made the following changes in AU Core Responder CapabilityStatement:
   - removed reference to Bulk Data Access implementation guide [FHIR-45113](https://jira.hl7.org/browse/FHIR-45113)
   - corrected the Observation combined search parameter 'patient+category+status' from SHALL to SHOULD [FHIR-45390](https://jira.hl7.org/browse/FHIR-45390)
@@ -189,4 +189,4 @@ This change log documents the significant updates and resolutions implemented fr
   - replaced security and authorization requirements with pointer to Security and Privacy page [FHIR-46067](https://jira.hl7.org/browse/FHIR-46067)
   - corrected narrative of PractitionerRole practitioner.identifier search parameter from Medicare Provider Number to HPI-I [FHIR-47013](https://jira.hl7.org/browse/FHIR-47013)
   - corrected support for Practitioner _id search parameter to be SHOULD instead of SHALL [FHIR-46777](https://jira.hl7.org/browse/FHIR-46777)
-  - added missing entry for DocumentReference and RelatedPerson resources [FHIR-46546](https://jira.hl7.org/browse/FHIR-46546)
+  - added missing entries for DocumentReference and RelatedPerson resources [FHIR-46546](https://jira.hl7.org/browse/FHIR-46546)

--- a/input/pagecontent/changes.md
+++ b/input/pagecontent/changes.md
@@ -180,7 +180,7 @@ This change log documents the significant updates and resolutions implemented fr
   - corrected the Observation combined search parameter 'patient+category+status' from SHALL to SHOULD [FHIR-45390](https://jira.hl7.org/browse/FHIR-45390)
   - corrected narrative of Location identifier parameter requester requirements on providing both the system and code values from SHOULD to MAY [FHIR-46209](https://jira.hl7.org/browse/FHIR-46209)
   - replaced security and authorization requirements with pointer to Security and Privacy page [FHIR-46067](https://jira.hl7.org/browse/FHIR-46067)
-  - added entries for referenced resources, DocumentReference and RelatedPerson, in line with the Must Support requirements in AU Core profiles [FHIR-46546](https://jira.hl7.org/browse/FHIR-46546)
+  - added missing entry for DocumentReference and RelatedPerson resources [FHIR-46546](https://jira.hl7.org/browse/FHIR-46546)
 - Made the following changes in AU Core Responder CapabilityStatement:
   - removed reference to Bulk Data Access implementation guide [FHIR-45113](https://jira.hl7.org/browse/FHIR-45113)
   - corrected the Observation combined search parameter 'patient+category+status' from SHALL to SHOULD [FHIR-45390](https://jira.hl7.org/browse/FHIR-45390)
@@ -189,4 +189,4 @@ This change log documents the significant updates and resolutions implemented fr
   - replaced security and authorization requirements with pointer to Security and Privacy page [FHIR-46067](https://jira.hl7.org/browse/FHIR-46067)
   - corrected narrative of PractitionerRole practitioner.identifier search parameter from Medicare Provider Number to HPI-I [FHIR-47013](https://jira.hl7.org/browse/FHIR-47013)
   - corrected support for Practitioner _id search parameter to be SHOULD instead of SHALL [FHIR-46777](https://jira.hl7.org/browse/FHIR-46777)
-  - added entries for referenced resources, DocumentReference and RelatedPerson, in line with the Must Support requirements in AU Core profiles [FHIR-46546](https://jira.hl7.org/browse/FHIR-46546)
+  - added missing entry for DocumentReference and RelatedPerson resources [FHIR-46546](https://jira.hl7.org/browse/FHIR-46546)

--- a/input/pagecontent/changes.md
+++ b/input/pagecontent/changes.md
@@ -180,6 +180,7 @@ This change log documents the significant updates and resolutions implemented fr
   - corrected the Observation combined search parameter 'patient+category+status' from SHALL to SHOULD [FHIR-45390](https://jira.hl7.org/browse/FHIR-45390)
   - corrected narrative of Location identifier parameter requester requirements on providing both the system and code values from SHOULD to MAY [FHIR-46209](https://jira.hl7.org/browse/FHIR-46209)
   - replaced security and authorization requirements with pointer to Security and Privacy page [FHIR-46067](https://jira.hl7.org/browse/FHIR-46067)
+  - added entries for referenced resources, DocumentReference and RelatedPerson, in line with the Must Support requirements in AU Core profiles [FHIR-46546](https://jira.hl7.org/browse/FHIR-46546)
 - Made the following changes in AU Core Responder CapabilityStatement:
   - removed reference to Bulk Data Access implementation guide [FHIR-45113](https://jira.hl7.org/browse/FHIR-45113)
   - corrected the Observation combined search parameter 'patient+category+status' from SHALL to SHOULD [FHIR-45390](https://jira.hl7.org/browse/FHIR-45390)
@@ -188,3 +189,4 @@ This change log documents the significant updates and resolutions implemented fr
   - replaced security and authorization requirements with pointer to Security and Privacy page [FHIR-46067](https://jira.hl7.org/browse/FHIR-46067)
   - corrected narrative of PractitionerRole practitioner.identifier search parameter from Medicare Provider Number to HPI-I [FHIR-47013](https://jira.hl7.org/browse/FHIR-47013)
   - corrected support for Practitioner _id search parameter to be SHOULD instead of SHALL [FHIR-46777](https://jira.hl7.org/browse/FHIR-46777)
+  - added entries for referenced resources, DocumentReference and RelatedPerson, in line with the Must Support requirements in AU Core profiles [FHIR-46546](https://jira.hl7.org/browse/FHIR-46546)

--- a/input/resources/au-core-requester.xml
+++ b/input/resources/au-core-requester.xml
@@ -857,6 +857,7 @@
 <div class="col-lg-3">
 <span class="lead">Profile Conformance</span>
 <br/>
+<b>SHALL</b>
 </div>
 <div class="col-lg-3">
 <span class="lead">Reference Policy</span>
@@ -876,7 +877,7 @@
 <span class="lead">Documentation</span>
 <blockquote>
 <div>
-<p>If the requester supports the DocumentReference resource, the requester SHALL support the conformance expectations for the DocumentReference resource.</p>
+<p>If the requester supports the DocumentReference resource, the requester <strong>SHALL</strong> support the conformance expectations for the DocumentReference resource.</p>
 </div>
 </blockquote>
 </div>
@@ -2943,6 +2944,7 @@
 <div class="col-lg-3">
 <span class="lead">Profile Conformance</span>
 <br/>
+<b>SHALL</b>
 </div>
 <div class="col-lg-3">
 <span class="lead">Reference Policy</span>
@@ -2962,7 +2964,7 @@
 <span class="lead">Documentation</span>
 <blockquote>
 <div>
-<p>If the requester supports the RelatedPerson resource, the requester SHALL support the AU Base profile and the conformance expectations for the RelatedPerson resource.</p>
+<p>If the requester supports the RelatedPerson resource, the requester <strong>SHALL</strong> support the AU Base profile and the conformance expectations for the RelatedPerson resource.</p>
 </div>
 </blockquote>
 </div>
@@ -3279,7 +3281,7 @@
 </extension>
 <type value="DocumentReference"/>
 <profile value="http://hl7.org/fhir/StructureDefinition/DocumentReference"/>
-<documentation value="If the requester supports the DocumentReference resource, the requester SHALL support the conformance expectations for the DocumentReference resource."/>
+<documentation value="If the requester supports the DocumentReference resource, the requester **SHALL** support the conformance expectations for the DocumentReference resource."/>
 </resource>
 <!-- ENCOUNTER :: DONE -->
 <resource>
@@ -4707,7 +4709,7 @@
 </extension>
 <type value="RelatedPerson"/>
 <profile value="http://hl7.org.au/fhir/StructureDefinition/au-relatedperson"/>
-<documentation value="If the requester supports the RelatedPerson resource, the requester SHALL support the AU Base profile and the conformance expectations for the RelatedPerson resource."/>
+<documentation value="If the requester supports the RelatedPerson resource, the requester **SHALL** support the AU Base profile and the conformance expectations for the RelatedPerson resource."/>
 </resource>
 <!-- INTERACTIONS -->
 <interaction>

--- a/input/resources/au-core-requester.xml
+++ b/input/resources/au-core-requester.xml
@@ -210,6 +210,23 @@
 </tr>
 <tr>
 <td>
+<a href="#DocumentReference1-1">DocumentReference</a>
+</td>
+<td>
+<a href="http://hl7.org/fhir/StructureDefinition/DocumentReference">http://hl7.org/fhir/StructureDefinition/DocumentReference</a>
+</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td/>
+<td>
+</td>
+<td/>
+</tr>
+<tr>
+<td>
 <a href="#Encounter1-1">Encounter</a>
 </td>
 <td>
@@ -403,6 +420,23 @@
 <td class="text-center"></td>
 <td>code, date, patient, patient.identifier, patient+code+date, patient+date, patient+status, status</td>
 <td></td>
+<td>
+</td>
+<td/>
+</tr>
+<tr>
+<td>
+<a href="#RelatedPerson1-1">RelatedPerson</a>
+</td>
+<td>
+<a href="http://hl7.org.au/fhir/StructureDefinition/au-relatedperson">http://hl7.org.au/fhir/StructureDefinition/au-relatedperson</a>
+</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td/>
 <td>
 </td>
 <td/>
@@ -802,6 +836,49 @@
 </tr>
 </tbody>
 </table>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="panel panel-default">
+<div class="panel-heading">
+<h4 id="DocumentReference1-1" class="panel-title">
+<span style="float: right;">Resource Conformance: SHOULD</span>DocumentReference</h4>
+</div>
+<div class="panel-body">
+<div class="container">
+<div class="row">
+<div class="col-lg-6">
+<span class="lead">Base System Profile</span>
+<br/>
+<a href="http://hl7.org/fhir/StructureDefinition/DocumentReference">http://hl7.org/fhir/StructureDefinition/DocumentReference</a>
+</div>
+<div class="col-lg-3">
+<span class="lead">Profile Conformance</span>
+<br/>
+</div>
+<div class="col-lg-3">
+<span class="lead">Reference Policy</span>
+<br/>
+</div>
+</div>
+<p/>
+<div class="row">
+<div class="col-lg-6">
+<span class="lead">Interaction summary</span>
+<br/>
+</div>
+</div>
+<p/>
+<div class="row">
+<div class="col-12">
+<span class="lead">Documentation</span>
+<blockquote>
+<div>
+<p>If the requester supports the DocumentReference resource, the requester SHALL support the conformance expectations for the DocumentReference resource.</p>
+</div>
+</blockquote>
 </div>
 </div>
 </div>
@@ -2850,6 +2927,49 @@
 </div>
 </div>
 </div>
+<div class="panel panel-default">
+<div class="panel-heading">
+<h4 id="RelatedPerson1-1" class="panel-title">
+<span style="float: right;">Resource Conformance: SHOULD</span>RelatedPerson</h4>
+</div>
+<div class="panel-body">
+<div class="container">
+<div class="row">
+<div class="col-lg-6">
+<span class="lead">Base System Profile</span>
+<br/>
+<a href="http://hl7.org.au/fhir/StructureDefinition/au-relatedperson">http://hl7.org.au/fhir/StructureDefinition/au-relatedperson</a>
+</div>
+<div class="col-lg-3">
+<span class="lead">Profile Conformance</span>
+<br/>
+</div>
+<div class="col-lg-3">
+<span class="lead">Reference Policy</span>
+<br/>
+</div>
+</div>
+<p/>
+<div class="row">
+<div class="col-lg-6">
+<span class="lead">Interaction summary</span>
+<br/>
+</div>
+</div>
+<p/>
+<div class="row">
+<div class="col-12">
+<span class="lead">Documentation</span>
+<blockquote>
+<div>
+<p>If the requester supports the RelatedPerson resource, the requester SHALL support the AU Base profile and the conformance expectations for the RelatedPerson resource.</p>
+</div>
+</blockquote>
+</div>
+</div>
+</div>
+</div>
+</div>
 </div>
 </text>
 <url value="http://hl7.org.au/fhir/core/CapabilityStatement/au-core-requester"/>
@@ -3151,6 +3271,15 @@
 <type value="reference"/>
 <documentation value="The requester **SHALL** provide at least an id value and **MAY** provide both the Type and id values.&#xa;&#xa;The responder **SHALL** support both.&#xa;&#xa;The requester **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile.&#xa;&#xa;The responder **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile."/>
 </searchParam>
+</resource>
+<!-- DOCUMENT REFERENCE :: DONE -->
+<resource>
+<extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+<valueCode value="SHOULD"/>
+</extension>
+<type value="DocumentReference"/>
+<profile value="http://hl7.org/fhir/StructureDefinition/DocumentReference"/>
+<documentation value="If the requester supports the DocumentReference resource, the requester SHALL support the conformance expectations for the DocumentReference resource."/>
 </resource>
 <!-- ENCOUNTER :: DONE -->
 <resource>
@@ -4570,6 +4699,15 @@
 <type value="reference"/>
 <documentation value="The requester **SHALL** provide at least an id value and **MAY** provide both the Type and id values.&#xa;&#xa;The responder **SHALL** support both.&#xa;&#xa;The requester **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile.&#xa;&#xa;The responder **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile."/>
 </searchParam>
+</resource>
+<!-- RELATED PERSON :: DONE -->
+<resource>
+<extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+<valueCode value="SHOULD"/>
+</extension>
+<type value="RelatedPerson"/>
+<profile value="http://hl7.org.au/fhir/StructureDefinition/au-relatedperson"/>
+<documentation value="If the requester supports the RelatedPerson resource, the requester SHALL support the AU Base profile and the conformance expectations for the RelatedPerson resource."/>
 </resource>
 <!-- INTERACTIONS -->
 <interaction>

--- a/input/resources/au-core-responder.xml
+++ b/input/resources/au-core-responder.xml
@@ -232,6 +232,22 @@
 </tr>
 <tr>
 <td>
+<a href="#DocumentReference1-1">DocumentReference</a>
+</td>
+<td>
+<a href="http://hl7.org/fhir/StructureDefinition/DocumentReference">http://hl7.org/fhir/StructureDefinition/DocumentReference</a>
+</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td/>
+<td></td>
+<td/>
+</tr>
+<tr>
+<td>
 <a href="#Encounter1-1">Encounter</a>
 </td>
 <td>
@@ -417,6 +433,22 @@
 <td></td>
 <td>
 </td>
+<td/>
+</tr>
+<tr>
+<td>
+<a href="#RelatedPerson1-1">RelatedPerson</a>
+</td>
+<td>
+<a href="http://hl7.org.au/fhir/StructureDefinition/au-relatedperson">http://hl7.org.au/fhir/StructureDefinition/au-relatedperson</a>
+</td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td></td>
+<td/>
+<td></td>
 <td/>
 </tr>
 </tbody>
@@ -814,6 +846,49 @@
 </tr>
 </tbody>
 </table>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="panel panel-default">
+<div class="panel-heading">
+<h4 id="DocumentReference1-1" class="panel-title">
+<span style="float: right;">Resource Conformance: SHOULD</span>DocumentReference</h4>
+</div>
+<div class="panel-body">
+<div class="container">
+<div class="row">
+<div class="col-lg-6">
+<span class="lead">Base System Profile</span>
+<br/>
+<a href="http://hl7.org/fhir/StructureDefinition/DocumentReference">http://hl7.org/fhir/StructureDefinition/DocumentReference</a>
+</div>
+<div class="col-lg-3">
+<span class="lead">Profile Conformance</span>
+<br/>
+</div>
+<div class="col-lg-3">
+<span class="lead">Reference Policy</span>
+<br/>
+</div>
+</div>
+<p/>
+<div class="row">
+<div class="col-lg-6">
+<span class="lead">Interaction summary</span>
+<br/>
+</div>
+</div>
+<p/>
+<div class="row">
+<div class="col-12">
+<span class="lead">Documentation</span>
+<blockquote>
+<div>
+<p>If the responder supports the DocumentReference resource, the responder SHALL support the conformance expectations for the DocumentReference resource.</p>
+</div>
+</blockquote>
 </div>
 </div>
 </div>
@@ -2859,6 +2934,49 @@
 </div>
 </div>
 </div>
+<div class="panel panel-default">
+<div class="panel-heading">
+<h4 id="RelatedPerson1-1" class="panel-title">
+<span style="float: right;">Resource Conformance: SHOULD</span>RelatedPerson</h4>
+</div>
+<div class="panel-body">
+<div class="container">
+<div class="row">
+<div class="col-lg-6">
+<span class="lead">Base System Profile</span>
+<br/>
+<a href="http://hl7.org.au/fhir/StructureDefinition/au-relatedperson">http://hl7.org.au/fhir/StructureDefinition/au-relatedperson</a>
+</div>
+<div class="col-lg-3">
+<span class="lead">Profile Conformance</span>
+<br/>
+</div>
+<div class="col-lg-3">
+<span class="lead">Reference Policy</span>
+<br/>
+</div>
+</div> 
+<p/>
+<div class="row">
+<div class="col-lg-6">
+<span class="lead">Interaction summary</span>
+<br/>
+</div>
+</div>
+<p/>
+<div class="row">
+<div class="col-12">
+<span class="lead">Documentation</span>
+<blockquote>
+<div>
+<p>If the responder supports the RelatedPerson resource, the responder SHALL support the AU Base profile and the conformance expectations for the RelatedPerson resource.</p>
+</div>
+</blockquote>
+</div>
+</div>
+</div>
+</div>
+</div>
 </div>
 </text>
 <url value="http://hl7.org.au/fhir/core/CapabilityStatement/au-core-responder"/>
@@ -3158,6 +3276,14 @@
 <type value="reference"/>
 <documentation value="The requester **SHALL** provide at least an id value and **MAY** provide both the Type and id values.&#xa;&#xa;The responder **SHALL** support both.&#xa;&#xa;The requester **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile.&#xa;&#xa;The responder **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile."/>
 </searchParam>
+</resource><!-- DOCUMENT REFERENCE :: DONE -->
+<resource>
+<extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+<valueCode value="SHOULD"/>
+</extension>
+<type value="DocumentReference"/>
+<profile value="http://hl7.org/fhir/StructureDefinition/DocumentReference"/>
+<documentation value="If the responder supports the DocumentReference resource, the responder SHALL support the conformance expectations for the DocumentReference resource."/>
 </resource><!-- ENCOUNTER :: DONE -->
 <resource>
 <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
@@ -4568,6 +4694,14 @@
 <type value="reference"/>
 <documentation value="The requester **SHALL** provide at least an id value and **MAY** provide both the Type and id values.&#xa;&#xa;The responder **SHALL** support both.&#xa;&#xa;The requester **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile.&#xa;&#xa;The responder **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile."/>
 </searchParam>
+</resource><!-- RELATED PERSON :: DONE -->
+<resource>
+<extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+<valueCode value="SHOULD"/>
+</extension>
+<type value="RelatedPerson"/>
+<profile value="http://hl7.org.au/fhir/StructureDefinition/au-relatedperson"/>
+<documentation value="If the responder supports the RelatedPerson resource, the responder SHALL support the AU Base profile and the conformance expectations for the RelatedPerson resource."/>
 </resource>
 <!-- INTERACTIONS -->
 <interaction>

--- a/input/resources/au-core-responder.xml
+++ b/input/resources/au-core-responder.xml
@@ -867,6 +867,7 @@
 <div class="col-lg-3">
 <span class="lead">Profile Conformance</span>
 <br/>
+<b>SHALL</b>
 </div>
 <div class="col-lg-3">
 <span class="lead">Reference Policy</span>
@@ -886,7 +887,7 @@
 <span class="lead">Documentation</span>
 <blockquote>
 <div>
-<p>If the responder supports the DocumentReference resource, the responder SHALL support the conformance expectations for the DocumentReference resource.</p>
+<p>If the responder supports the DocumentReference resource, the responder <strong>SHALL</strong> support the conformance expectations for the DocumentReference resource.</p>
 </div>
 </blockquote>
 </div>
@@ -2950,6 +2951,7 @@
 <div class="col-lg-3">
 <span class="lead">Profile Conformance</span>
 <br/>
+<b>SHALL</b>
 </div>
 <div class="col-lg-3">
 <span class="lead">Reference Policy</span>
@@ -2969,7 +2971,7 @@
 <span class="lead">Documentation</span>
 <blockquote>
 <div>
-<p>If the responder supports the RelatedPerson resource, the responder SHALL support the AU Base profile and the conformance expectations for the RelatedPerson resource.</p>
+<p>If the responder supports the RelatedPerson resource, the responder <strong>SHALL</strong> support the AU Base profile and the conformance expectations for the RelatedPerson resource.</p>
 </div>
 </blockquote>
 </div>
@@ -3283,7 +3285,7 @@
 </extension>
 <type value="DocumentReference"/>
 <profile value="http://hl7.org/fhir/StructureDefinition/DocumentReference"/>
-<documentation value="If the responder supports the DocumentReference resource, the responder SHALL support the conformance expectations for the DocumentReference resource."/>
+<documentation value="If the responder supports the DocumentReference resource, the responder **SHALL** support the conformance expectations for the DocumentReference resource."/>
 </resource><!-- ENCOUNTER :: DONE -->
 <resource>
 <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
@@ -4701,7 +4703,7 @@
 </extension>
 <type value="RelatedPerson"/>
 <profile value="http://hl7.org.au/fhir/StructureDefinition/au-relatedperson"/>
-<documentation value="If the responder supports the RelatedPerson resource, the responder SHALL support the AU Base profile and the conformance expectations for the RelatedPerson resource."/>
+<documentation value="If the responder supports the RelatedPerson resource, the responder **SHALL** support the AU Base profile and the conformance expectations for the RelatedPerson resource."/>
 </resource>
 <!-- INTERACTIONS -->
 <interaction>


### PR DESCRIPTION
This PR fixes [FHIR-46546](https://jira.hl7.org/browse/FHIR-46546)

Changes:
* AU Core Requester CapabilityStatement: add entry for DocumentReference and RelatedPerson
* AU Core Responder CapabilityStatement: add entry for DocumentReference and RelatedPerson
* Change log