### PR TITLE
Remove MS, Obligations and cardinality from DiagResult & PathResult (FHIR-48331, FHIR-46737, FHIR-46731, FHIR-46732)

### DIFF
--- a/input/examples/pathresult-covid-1.xml
+++ b/input/examples/pathresult-covid-1.xml
@@ -4,32 +4,6 @@
     <meta>
         <profile value="http://hl7.org.au/fhir/core/StructureDefinition/au-core-diagnosticresult-path"/>
     </meta>
-    <identifier>
-        <type>
-            <coding>
-                <system value="http://terminology.hl7.org/CodeSystem/v2-0203"/>
-                <code value="PLAC"/>
-                <display value="Placer Identifier"/>
-            </coding>
-            <text value="Placer Order Identifier"/>
-        </type>
-        <system value="http://bobrestergp.example.com/order"/>
-        <value value="3451451243"/>
-        <assigner>
-            <display value ="Bobregster Medical Center QLD"/>
-        </assigner>
-    </identifier>
-    <identifier>
-        <type>
-            <coding>
-                <system value="http://terminology.hl7.org/CodeSystem/v2-0203"/>
-                <code value="FILL"/>
-                <display value="Filler Identifier"/>
-            </coding>
-        </type>
-        <system value="http://ns.electronichealth.net.au/id/hpio-scoped/report/1.0/8003621566684455"/>
-        <value value="8328qjs"/>
-    </identifier>
     <status value="final"/>
     <category>
         <coding>
@@ -65,12 +39,6 @@
         </coding>
         <text value="Not detected"/>
     </valueCodeableConcept>
-    <note>
-        <text value="PATHOLOGY LAB NATA/RCPA accreditation does not cover the SARS-CoV-2 (COVID-19) PCR test."/>
-    </note>
-    <note>
-        <text value="This test is currently under evaluation and has not been fully validated. Failure to detect organism-specific nucleic acids does not exclude the presence of disease due to this agent."/>
-    </note>
     <specimen>
         <reference value="Specimen/nasoswab"/>
     </specimen>

--- a/input/pagecontent/changes.md
+++ b/input/pagecontent/changes.md
@@ -169,15 +169,13 @@ This change log documents the significant updates and resolutions implemented fr
   - in Observation.performer replaced RelatedPerson with AU Base RelatedPerson [FHIR-45228](https://jira.hl7.org/browse/FHIR-45228)
   - removed the required binding to ObservationStatus Result Available value set from Observation.status [FHIR-45125](https://jira.hl7.org/browse/FHIR-45125)
   - updated invariant au-core-obs-01 to change the length check from >= 10 to >= 8 to match required precision to the day [FHIR-46407](https://jira.hl7.org/browse/FHIR-46407)
-  - removed Obligations on Observation.hasMember.reference [FHIR-46728](https://jira.hl7.org/browse/FHIR-46728)
-  - removed the cardinality constraint on Observation.hasMember.reference, changing it from 1..1 to 0..1 [FHIR-48331](https://jira.hl7.org/browse/FHIR-48331)
+  - removed constraints from Observation.hasMember.reference [FHIR-46728](https://jira.hl7.org/browse/FHIR-46728), [FHIR-48331](https://jira.hl7.org/browse/FHIR-48331)
   - removed Must Support and Obligations from the identifier, interpretation, note, method and referenceRange elements [FHIR-46737](https://jira.hl7.org/browse/FHIR-46737)
 - Made the following changes to AU Core Pathology Result Observation:
   - in Observation.performer replaced RelatedPerson with AU Base RelatedPerson [FHIR-45228](https://jira.hl7.org/browse/FHIR-45228)
   - removed the required binding to ObservationStatus Result Available value set from Observation.status [FHIR-45125](https://jira.hl7.org/browse/FHIR-45125)
   - updated invariant au-core-obs-01 to change the length check from >= 10 to >= 8 to match required precision to the day [FHIR-46407](https://jira.hl7.org/browse/FHIR-46407)
-  - removed Obligations on Observation.hasMember.reference and Observation.specimen.reference [FHIR-46728](https://jira.hl7.org/browse/FHIR-46728)
-  - removed the cardinality constraint on Observation.hasMember.reference and Observation.specimen.reference, changing it from 1..1 to 0..1 [FHIR-46731](https://jira.hl7.org/browse/FHIR-46731)
+  - removed constraints from Observation.hasMember.reference and Observation.specimen.reference [FHIR-46728](https://jira.hl7.org/browse/FHIR-46728), [FHIR-46731](https://jira.hl7.org/browse/FHIR-46731)
   - removed Must Support and Obligations from the identifier, method and note elements [FHIR-46732](https://jira.hl7.org/browse/FHIR-46732)
 - Made the following changes in AU Core Requester CapabilityStatement:
   - removed reference to Bulk Data Access implementation guide [FHIR-45113](https://jira.hl7.org/browse/FHIR-45113)

--- a/input/pagecontent/changes.md
+++ b/input/pagecontent/changes.md
@@ -170,11 +170,15 @@ This change log documents the significant updates and resolutions implemented fr
   - removed the required binding to ObservationStatus Result Available value set from Observation.status [FHIR-45125](https://jira.hl7.org/browse/FHIR-45125)
   - updated invariant au-core-obs-01 to change the length check from >= 10 to >= 8 to match required precision to the day [FHIR-46407](https://jira.hl7.org/browse/FHIR-46407)
   - removed Obligations on Observation.hasMember.reference [FHIR-46728](https://jira.hl7.org/browse/FHIR-46728)
+  - removed the cardinality constraint on Observation.hasMember.reference, changing it from 1..1 to 0..1 [FHIR-48331](https://jira.hl7.org/browse/FHIR-48331)
+  - removed Must Support and Obligations from the identifier, interpretation, note, method and referenceRange elements [FHIR-46737](https://jira.hl7.org/browse/FHIR-46737)
 - Made the following changes to AU Core Pathology Result Observation:
   - in Observation.performer replaced RelatedPerson with AU Base RelatedPerson [FHIR-45228](https://jira.hl7.org/browse/FHIR-45228)
   - removed the required binding to ObservationStatus Result Available value set from Observation.status [FHIR-45125](https://jira.hl7.org/browse/FHIR-45125)
   - updated invariant au-core-obs-01 to change the length check from >= 10 to >= 8 to match required precision to the day [FHIR-46407](https://jira.hl7.org/browse/FHIR-46407)
   - removed Obligations on Observation.hasMember.reference and Observation.specimen.reference [FHIR-46728](https://jira.hl7.org/browse/FHIR-46728)
+  - removed the cardinality constraint on Observation.hasMember.reference and Observation.specimen.reference, changing it from 1..1 to 0..1 [FHIR-46731](https://jira.hl7.org/browse/FHIR-46731)
+  - removed Must Support and Obligations from the identifier, method and note elements [FHIR-46732](https://jira.hl7.org/browse/FHIR-46732)
 - Made the following changes in AU Core Requester CapabilityStatement:
   - removed reference to Bulk Data Access implementation guide [FHIR-45113](https://jira.hl7.org/browse/FHIR-45113)
   - corrected the Observation combined search parameter 'patient+category+status' from SHALL to SHOULD [FHIR-45390](https://jira.hl7.org/browse/FHIR-45390)

--- a/input/pagecontent/changes.md
+++ b/input/pagecontent/changes.md
@@ -170,13 +170,13 @@ This change log documents the significant updates and resolutions implemented fr
   - removed the required binding to ObservationStatus Result Available value set from Observation.status [FHIR-45125](https://jira.hl7.org/browse/FHIR-45125)
   - updated invariant au-core-obs-01 to change the length check from >= 10 to >= 8 to match required precision to the day [FHIR-46407](https://jira.hl7.org/browse/FHIR-46407)
   - removed constraints from Observation.hasMember.reference [FHIR-46728](https://jira.hl7.org/browse/FHIR-46728), [FHIR-48331](https://jira.hl7.org/browse/FHIR-48331)
-  - removed Must Support and Obligations from the identifier, interpretation, note, method and referenceRange elements [FHIR-46737](https://jira.hl7.org/browse/FHIR-46737)
+  - removed Must Support and Obligations from Observation.identifier, Observation.interpretation, Observation.note, Observation.method, Observation.referenceRange, Observation.referenceRange.low, Observation.referenceRange.high, Observation.referenceRange.type and Observation.referenceRange.text [FHIR-46737](https://jira.hl7.org/browse/FHIR-46737)
 - Made the following changes to AU Core Pathology Result Observation:
   - in Observation.performer replaced RelatedPerson with AU Base RelatedPerson [FHIR-45228](https://jira.hl7.org/browse/FHIR-45228)
   - removed the required binding to ObservationStatus Result Available value set from Observation.status [FHIR-45125](https://jira.hl7.org/browse/FHIR-45125)
   - updated invariant au-core-obs-01 to change the length check from >= 10 to >= 8 to match required precision to the day [FHIR-46407](https://jira.hl7.org/browse/FHIR-46407)
   - removed constraints from Observation.hasMember.reference and Observation.specimen.reference [FHIR-46728](https://jira.hl7.org/browse/FHIR-46728), [FHIR-46731](https://jira.hl7.org/browse/FHIR-46731)
-  - removed Must Support and Obligations from the identifier, method and note elements [FHIR-46732](https://jira.hl7.org/browse/FHIR-46732)
+  - removed Must Support and Obligations from Observation.identifier, Observation.method and Observation.note [FHIR-46732](https://jira.hl7.org/browse/FHIR-46732)
 - Made the following changes in AU Core Requester CapabilityStatement:
   - removed reference to Bulk Data Access implementation guide [FHIR-45113](https://jira.hl7.org/browse/FHIR-45113)
   - corrected the Observation combined search parameter 'patient+category+status' from SHALL to SHOULD [FHIR-45390](https://jira.hl7.org/browse/FHIR-45390)

--- a/input/resources/au-core-diagnosticresult-path.xml
+++ b/input/resources/au-core-diagnosticresult-path.xml
@@ -26,26 +26,6 @@
         <source value="http://hl7.org.au/fhir/core/StructureDefinition/au-core-diagnosticresult-path"/>
       </constraint>
     </element>
-    <element id="Observation.identifier">
-      <extension url="http://hl7.org/fhir/StructureDefinition/obligation">
-        <extension url="code">
-          <valueCode value="SHALL:populate-if-known"/>
-        </extension>
-        <extension url="actor">
-          <valueCanonical value="http://hl7.org.au/fhir/core/ActorDefinition/au-core-actor-responder"/>
-        </extension>
-      </extension>
-      <extension url="http://hl7.org/fhir/StructureDefinition/obligation">
-        <extension url="code">
-          <valueCode value="SHALL:no-error"/>
-        </extension>
-        <extension url="actor">
-          <valueCanonical value="http://hl7.org.au/fhir/core/ActorDefinition/au-core-actor-requester"/>
-        </extension>
-      </extension>
-      <path value="Observation.identifier"/>
-      <mustSupport value="true"/>
-    </element>
     <element id="Observation.status">
       <extension url="http://hl7.org/fhir/StructureDefinition/obligation">
         <extension url="code">
@@ -257,46 +237,6 @@
       <path value="Observation.interpretation"/>
       <mustSupport value="true"/>
     </element>
-    <element id="Observation.note">
-      <extension url="http://hl7.org/fhir/StructureDefinition/obligation">
-        <extension url="code">
-          <valueCode value="SHALL:populate-if-known"/>
-        </extension>
-        <extension url="actor">
-          <valueCanonical value="http://hl7.org.au/fhir/core/ActorDefinition/au-core-actor-responder"/>
-        </extension>
-      </extension>
-      <extension url="http://hl7.org/fhir/StructureDefinition/obligation">
-        <extension url="code">
-          <valueCode value="SHALL:no-error"/>
-        </extension>
-        <extension url="actor">
-          <valueCanonical value="http://hl7.org.au/fhir/core/ActorDefinition/au-core-actor-requester"/>
-        </extension>
-      </extension>
-      <path value="Observation.note"/>
-      <mustSupport value="true"/>
-    </element>
-    <element id="Observation.method">
-      <extension url="http://hl7.org/fhir/StructureDefinition/obligation">
-        <extension url="code">
-          <valueCode value="SHALL:populate-if-known"/>
-        </extension>
-        <extension url="actor">
-          <valueCanonical value="http://hl7.org.au/fhir/core/ActorDefinition/au-core-actor-responder"/>
-        </extension>
-      </extension>
-      <extension url="http://hl7.org/fhir/StructureDefinition/obligation">
-        <extension url="code">
-          <valueCode value="SHALL:no-error"/>
-        </extension>
-        <extension url="actor">
-          <valueCanonical value="http://hl7.org.au/fhir/core/ActorDefinition/au-core-actor-requester"/>
-        </extension>
-      </extension>
-      <path value="Observation.method"/>
-      <mustSupport value="true"/>
-    </element>
     <element id="Observation.specimen">
       <extension url="http://hl7.org/fhir/StructureDefinition/obligation">
         <extension url="code">
@@ -319,7 +259,7 @@
     </element>
     <element id="Observation.specimen.reference">
       <path value="Observation.specimen.reference"/>
-      <min value="1"/>
+      <min value="0"/>
     </element>
     <element id="Observation.referenceRange">
       <extension url="http://hl7.org/fhir/StructureDefinition/obligation">
@@ -448,7 +388,7 @@
     </element>
     <element id="Observation.hasMember.reference">
       <path value="Observation.hasMember.reference"/>
-      <min value="1"/>
+      <min value="0"/>
     </element>
     <element id="Observation.component">
       <extension url="http://hl7.org/fhir/StructureDefinition/obligation">

--- a/input/resources/au-core-diagnosticresult-path.xml
+++ b/input/resources/au-core-diagnosticresult-path.xml
@@ -257,10 +257,6 @@
       <path value="Observation.specimen"/>
       <mustSupport value="true"/>
     </element>
-    <element id="Observation.specimen.reference">
-      <path value="Observation.specimen.reference"/>
-      <min value="0"/>
-    </element>
     <element id="Observation.referenceRange">
       <extension url="http://hl7.org/fhir/StructureDefinition/obligation">
         <extension url="code">
@@ -385,10 +381,6 @@
         <targetProfile value="http://hl7.org.au/fhir/core/StructureDefinition/au-core-diagnosticresult-path"/>
       </type>
       <mustSupport value="true"/>
-    </element>
-    <element id="Observation.hasMember.reference">
-      <path value="Observation.hasMember.reference"/>
-      <min value="0"/>
     </element>
     <element id="Observation.component">
       <extension url="http://hl7.org/fhir/StructureDefinition/obligation">

--- a/input/resources/au-core-diagnosticresult.xml
+++ b/input/resources/au-core-diagnosticresult.xml
@@ -26,26 +26,6 @@
         <source value="http://hl7.org.au/fhir/core/StructureDefinition/au-core-diagnosticresult"/>
       </constraint>
     </element>
-    <element id="Observation.identifier">
-      <extension url="http://hl7.org/fhir/StructureDefinition/obligation">
-        <extension url="code">
-          <valueCode value="SHALL:populate-if-known"/>
-        </extension>
-        <extension url="actor">
-          <valueCanonical value="http://hl7.org.au/fhir/core/ActorDefinition/au-core-actor-responder"/>
-        </extension>
-      </extension>
-      <extension url="http://hl7.org/fhir/StructureDefinition/obligation">
-        <extension url="code">
-          <valueCode value="SHALL:no-error"/>
-        </extension>
-        <extension url="actor">
-          <valueCanonical value="http://hl7.org.au/fhir/core/ActorDefinition/au-core-actor-requester"/>
-        </extension>
-      </extension>
-      <path value="Observation.identifier"/>
-      <mustSupport value="true"/>
-    </element>
     <element id="Observation.status">
       <extension url="http://hl7.org/fhir/StructureDefinition/obligation">
         <extension url="code">
@@ -234,46 +214,6 @@
       <condition value="au-core-obs-05"/>
       <mustSupport value="true"/>
     </element>
-    <element id="Observation.interpretation">
-      <extension url="http://hl7.org/fhir/StructureDefinition/obligation">
-        <extension url="code">
-          <valueCode value="SHALL:populate-if-known"/>
-        </extension>
-        <extension url="actor">
-          <valueCanonical value="http://hl7.org.au/fhir/core/ActorDefinition/au-core-actor-responder"/>
-        </extension>
-      </extension>
-      <extension url="http://hl7.org/fhir/StructureDefinition/obligation">
-        <extension url="code">
-          <valueCode value="SHALL:no-error"/>
-        </extension>
-        <extension url="actor">
-          <valueCanonical value="http://hl7.org.au/fhir/core/ActorDefinition/au-core-actor-requester"/>
-        </extension>
-      </extension>
-      <path value="Observation.interpretation"/>
-      <mustSupport value="true"/>
-    </element>
-    <element id="Observation.note">
-      <extension url="http://hl7.org/fhir/StructureDefinition/obligation">
-        <extension url="code">
-          <valueCode value="SHALL:populate-if-known"/>
-        </extension>
-        <extension url="actor">
-          <valueCanonical value="http://hl7.org.au/fhir/core/ActorDefinition/au-core-actor-responder"/>
-        </extension>
-      </extension>
-      <extension url="http://hl7.org/fhir/StructureDefinition/obligation">
-        <extension url="code">
-          <valueCode value="SHALL:no-error"/>
-        </extension>
-        <extension url="actor">
-          <valueCanonical value="http://hl7.org.au/fhir/core/ActorDefinition/au-core-actor-requester"/>
-        </extension>
-      </extension>
-      <path value="Observation.note"/>
-      <mustSupport value="true"/>
-    </element>
     <element id="Observation.bodySite">
       <extension url="http://hl7.org/fhir/StructureDefinition/obligation">
         <extension url="code">
@@ -307,126 +247,6 @@
         <valueSet value="https://healthterminologies.gov.au/fhir/ValueSet/body-site-1"/>
       </binding>
     </element>
-    <element id="Observation.method">
-      <extension url="http://hl7.org/fhir/StructureDefinition/obligation">
-        <extension url="code">
-          <valueCode value="SHALL:populate-if-known"/>
-        </extension>
-        <extension url="actor">
-          <valueCanonical value="http://hl7.org.au/fhir/core/ActorDefinition/au-core-actor-responder"/>
-        </extension>
-      </extension>
-      <extension url="http://hl7.org/fhir/StructureDefinition/obligation">
-        <extension url="code">
-          <valueCode value="SHALL:no-error"/>
-        </extension>
-        <extension url="actor">
-          <valueCanonical value="http://hl7.org.au/fhir/core/ActorDefinition/au-core-actor-requester"/>
-        </extension>
-      </extension>
-      <path value="Observation.method"/>
-      <mustSupport value="true"/>
-    </element>
-    <element id="Observation.referenceRange">
-      <extension url="http://hl7.org/fhir/StructureDefinition/obligation">
-        <extension url="code">
-          <valueCode value="SHALL:populate-if-known"/>
-        </extension>
-        <extension url="actor">
-          <valueCanonical value="http://hl7.org.au/fhir/core/ActorDefinition/au-core-actor-responder"/>
-        </extension>
-      </extension>
-      <extension url="http://hl7.org/fhir/StructureDefinition/obligation">
-        <extension url="code">
-          <valueCode value="SHALL:no-error"/>
-        </extension>
-        <extension url="actor">
-          <valueCanonical value="http://hl7.org.au/fhir/core/ActorDefinition/au-core-actor-requester"/>
-        </extension>
-      </extension>
-      <path value="Observation.referenceRange"/>
-      <mustSupport value="true"/>
-    </element>
-    <element id="Observation.referenceRange.low">
-      <extension url="http://hl7.org/fhir/StructureDefinition/obligation">
-        <extension url="code">
-          <valueCode value="SHALL:populate-if-known"/>
-        </extension>
-        <extension url="actor">
-          <valueCanonical value="http://hl7.org.au/fhir/core/ActorDefinition/au-core-actor-responder"/>
-        </extension>
-      </extension>
-      <extension url="http://hl7.org/fhir/StructureDefinition/obligation">
-        <extension url="code">
-          <valueCode value="SHALL:no-error"/>
-        </extension>
-        <extension url="actor">
-          <valueCanonical value="http://hl7.org.au/fhir/core/ActorDefinition/au-core-actor-requester"/>
-        </extension>
-      </extension>
-      <path value="Observation.referenceRange.low"/>
-      <mustSupport value="true"/>
-    </element>
-    <element id="Observation.referenceRange.high">
-      <extension url="http://hl7.org/fhir/StructureDefinition/obligation">
-        <extension url="code">
-          <valueCode value="SHALL:populate-if-known"/>
-        </extension>
-        <extension url="actor">
-          <valueCanonical value="http://hl7.org.au/fhir/core/ActorDefinition/au-core-actor-responder"/>
-        </extension>
-      </extension>
-      <extension url="http://hl7.org/fhir/StructureDefinition/obligation">
-        <extension url="code">
-          <valueCode value="SHALL:no-error"/>
-        </extension>
-        <extension url="actor">
-          <valueCanonical value="http://hl7.org.au/fhir/core/ActorDefinition/au-core-actor-requester"/>
-        </extension>
-      </extension>
-      <path value="Observation.referenceRange.high"/>
-      <mustSupport value="true"/>
-    </element>
-    <element id="Observation.referenceRange.type">
-      <extension url="http://hl7.org/fhir/StructureDefinition/obligation">
-        <extension url="code">
-          <valueCode value="SHALL:populate-if-known"/>
-        </extension>
-        <extension url="actor">
-          <valueCanonical value="http://hl7.org.au/fhir/core/ActorDefinition/au-core-actor-responder"/>
-        </extension>
-      </extension>
-      <extension url="http://hl7.org/fhir/StructureDefinition/obligation">
-        <extension url="code">
-          <valueCode value="SHALL:no-error"/>
-        </extension>
-        <extension url="actor">
-          <valueCanonical value="http://hl7.org.au/fhir/core/ActorDefinition/au-core-actor-requester"/>
-        </extension>
-      </extension>
-      <path value="Observation.referenceRange.type"/>
-      <mustSupport value="true"/>
-    </element>
-    <element id="Observation.referenceRange.text">
-      <extension url="http://hl7.org/fhir/StructureDefinition/obligation">
-        <extension url="code">
-          <valueCode value="SHALL:populate-if-known"/>
-        </extension>
-        <extension url="actor">
-          <valueCanonical value="http://hl7.org.au/fhir/core/ActorDefinition/au-core-actor-responder"/>
-        </extension>
-      </extension>
-      <extension url="http://hl7.org/fhir/StructureDefinition/obligation">
-        <extension url="code">
-          <valueCode value="SHALL:no-error"/>
-        </extension>
-        <extension url="actor">
-          <valueCanonical value="http://hl7.org.au/fhir/core/ActorDefinition/au-core-actor-requester"/>
-        </extension>
-      </extension>
-      <path value="Observation.referenceRange.text"/>
-      <mustSupport value="true"/>
-    </element>
     <element id="Observation.hasMember">
       <extension url="http://hl7.org/fhir/StructureDefinition/obligation">
         <extension url="code">
@@ -455,7 +275,7 @@
     </element>
     <element id="Observation.hasMember.reference">
       <path value="Observation.hasMember.reference"/>
-      <min value="1"/>
+      <min value="0"/>
     </element>
     <element id="Observation.component">
       <extension url="http://hl7.org/fhir/StructureDefinition/obligation">

--- a/input/resources/au-core-diagnosticresult.xml
+++ b/input/resources/au-core-diagnosticresult.xml
@@ -273,10 +273,6 @@
       </type>
       <mustSupport value="true"/>
     </element>
-    <element id="Observation.hasMember.reference">
-      <path value="Observation.hasMember.reference"/>
-      <min value="0"/>
-    </element>
     <element id="Observation.component">
       <extension url="http://hl7.org/fhir/StructureDefinition/obligation">
         <extension url="code">


### PR DESCRIPTION
This PR fixes the following.

AU Core Diagnostic Result Observation
* [FHIR-48331](https://jira.hl7.org/browse/FHIR-48331) hasMember.reference to min cardinality of 0
* [FHIR-46737](https://jira.hl7.org/browse/FHIR-46737) Remove MustSupport and Obligation from identifier, interpretation, note, method and referenceRange elements

AU Core Pathology Result Observation
* [FHIR-46731](https://jira.hl7.org/browse/FHIR-46731) hasMember.reference and specimen.reference to min cardinality of 0
* [FHIR-46732](https://jira.hl7.org/browse/FHIR-46732) Remove MustSupport and Obligation from identifier, method and note elements

Changes to:
* Change log
* AU Core Pathology Result Observation
* AU Core Diagnostic Result Observation
