### PR TITLE
Corrected AU TDG name in the Home page (FHIR-47180)

### DIFF
--- a/input/pagecontent/index.md
+++ b/input/pagecontent/index.md
@@ -113,7 +113,7 @@ This guide is divided into several pages which are listed at the top of each pag
 ### Collaboration
 This guide is the product of collaborative work undertaken with participants from:
 
-* [Sparked HL7 AU Technical Design Group](https://confluence.hl7.org/display/HAFWG/HL7+Australia+-+AU+Core+Technical+Design+Group+Home)
+* [HL7 Australia AU Core Technical Design Group](https://confluence.hl7.org/display/HAFWG/HL7+Australia+-+AU+Core+Technical+Design+Group+Home)
 * [HL7 Australia FHIR Working Group](https://confluence.hl7.org/display/HAFWG/HL7+Australia+FHIR+Work+Group+Home)
 * Australian FHIR Implementers Community
 


### PR DESCRIPTION
Fix for https://jira.hl7.org/browse/FHIR-47180.