### PR TITLE
Gen Guidance - Contained Resources & Representing body site changes

### DIFF
--- a/input/pagecontent/general-guidance.md
+++ b/input/pagecontent/general-guidance.md
@@ -4,7 +4,7 @@ In some circumstances, the content referred to in the resource reference does no
 In AU Core profiles:
 - Systems constructing a resource that represent medication information are encouraged to make use of contained resources within the context of a FHIR transaction. Operations on Medication resources are expected to be within the context of a referencing resource query such as an MedicationAdministration, MedicationDispense, MedicationRequest or MedicationStatement.
 - If referencing a contained resource, both the contained resource and the referencing resource **SHALL** conform to the applicable AU Core profile.
-- Otherwise, when responding to a query, it is recommended that servers avoid using inline contained resources to represent the returned data.
+- Otherwise, it is recommended that an AU Core Responder avoids the use of contained resources unless the referenced resource does not have an independent existence apart from the resource that contains it and cannot be identified independently.
 
 Further guidance about the general use case for [contained resources](http://hl7.org/fhir/R4/references.html#contained) can be found in the base FHIR specification.
 
@@ -153,7 +153,7 @@ Example: Condition resource cellulitis of right knee
 2\. Primary finding/procedure `code` only (pre-coordinated code including body site without laterality and separate laterality qualifier)
 * For systems that have pre-coordinated coding describing a concept including body site without laterality, and have a laterality qualifier recorded separately e.g. left, right:
   * use the `code` element:
-    * `code.coding` contains the primary concept (no body site information).
+    * `code.coding` contains the primary concept including body site (without laterality).
     * `code.text` is used to describe concept fully, this can include information on recorded laterality e.g. ', Right'.
   * in this case laterality is not expressed in coded form.
 
@@ -181,7 +181,7 @@ Example: Condition resource showing coded condition that includes body site, lat
 3\. Coded `body site` with laterality and separate primary finding/procedure `code`.
 * For systems that have pre-coordinated coding describing primary concept without body site and separate body site with laterality recorded as coded value:
   * use the code element:
-    * `code.coding` contains the primary concept including body site without laterality.
+    * `code.coding` contains the primary concept alone (no body site or laterality).
     * `code.text` describes the concept fully, this can include information on recorded body site and laterality as text.
   * optionally, coded element `bodySite` may be supplied containing the coded body site with laterality.
 
@@ -225,7 +225,6 @@ Example: Condition resource showing coded condition, coded body site that includ
   * optionally, coded element bodySite may be supplied containing:
     * `bodySite.coding` contains the coded body site without laterality.
     * `bodySite.text` describes the body site concept fully, this can include information on recorded laterality as text e.g. ', Right'.
-  * coded laterality is supplied as the text in `bodySite.text`   
 
 
 Example: Condition resource with coded condition, coded body site, laterality as text only


### PR DESCRIPTION
Fix for [FHIR-47019](https://jira.hl7.org/browse/FHIR-47019) & [FHIR-46724](https://jira.hl7.org/browse/FHIR-46724):
* Change "Otherwise, when responding to a query, it is recommended that servers avoid using inline contained resources to represent the returned data." to "Otherwise, it is recommended that an AU Core Responder avoids the use of contained resources unless the referenced resource does not have an independent existence apart from the resource that contains it and cannot be identified independently.”

Fix for [FHIR-46739](https://jira.hl7.org/browse/FHIR-46739) (encompasses changes for [FHIR-47018](https://jira.hl7.org/browse/FHIR-47018) & [FHIR-47021](https://jira.hl7.org/browse/FHIR-47021)):
* Replace "code.coding contains the primary concept (no body site information)" with "code.coding contains the primary concept including body site (without laterality)"
* Replace "code.coding contains the primary concept including body site without laterality" with "code.coding contains the primary concept alone (no body site or laterality)"
* Remove "coded laterality is supplied as the text in bodySite.text"
