### PR TITLE
Read/Search Syntax & Medicinal Product Identification guidance changes

### DIFF
--- a/input/pagecontent/changes.md
+++ b/input/pagecontent/changes.md
@@ -1,3 +1,14 @@
+###  Release 1.0.0
+- Expected Publication date: 2025-01
+- Expected Publication status: TBC
+- Based on FHIR version: 4.0.1
+
+This change log documents the significant updates and resolutions implemented from version 1.0.0-ballot to 1.0.0.
+
+#### Changes in this version
+- Clarify Read/Search Syntax guidance [FHIR-46470](https://jira.hl7.org/browse/FHIR-46740), [FHIR-47194](https://jira.hl7.org/browse/FHIR-47194)
+- Clarify Medicine Information guidance for extemporaneous and non-extemporaneous medicinal product identification [FHIR-46741](https://jira.hl7.org/browse/FHIR-46741), [FHIR-46742](https://jira.hl7.org/browse/FHIR-46742)
+
 ###  Release 1.0.0-ballot
 - Expected Publication date: 2024-08-05
 - Expected Publication status: Ballot

--- a/input/pagecontent/changes.md
+++ b/input/pagecontent/changes.md
@@ -1,14 +1,3 @@
-###  Release 1.0.0
-- Expected Publication date: 2025-01
-- Expected Publication status: TBC
-- Based on FHIR version: 4.0.1
-
-This change log documents the significant updates and resolutions implemented from version 1.0.0-ballot to 1.0.0.
-
-#### Changes in this version
-- Clarify Read/Search Syntax guidance [FHIR-46470](https://jira.hl7.org/browse/FHIR-46740), [FHIR-47194](https://jira.hl7.org/browse/FHIR-47194)
-- Clarify Medicine Information guidance for extemporaneous and non-extemporaneous medicinal product identification [FHIR-46741](https://jira.hl7.org/browse/FHIR-46741), [FHIR-46742](https://jira.hl7.org/browse/FHIR-46742)
-
 ###  Release 1.0.0-ballot
 - Expected Publication date: 2024-08-05
 - Expected Publication status: Ballot

--- a/input/pagecontent/general-guidance.md
+++ b/input/pagecontent/general-guidance.md
@@ -259,7 +259,7 @@ Example: Condition resource with coded condition, coded body site, laterality as
 
 ### Read/Search Syntax
 
-Searching resources is defined by the [FHIR RESTful API](https://hl7.org/fhir/R4/http.html) and included here for informative purposes. The [AU Core CapabilityStatements](capability-statements.html) document the server and client rules for the RESTful interactions described in this guide. Examples in AU Core do not demonstrate the url encoding [rules for special characters](https://hl7.org/fhir/R4/search.html#escaping) e.g. "\|".
+Searching resources is defined by the [FHIR RESTful API](https://hl7.org/fhir/R4/http.html) and included here for informative purposes. The [AU Core CapabilityStatements](capability-statements.html) document the server and client rules for the RESTful interactions described in this guide.
 
 All the search interaction examples in this guide use the HTTP GET method with the following syntax:
 
@@ -288,4 +288,4 @@ In the simplest case, a search is executed by performing a GET operation in the 
 
 For this RESTful search, the parameters are a series of name=\[value\] pairs encoded in the URL. The search parameter names are defined for each resource. For example, the Observation resource has the name "code" for searching on the LOINC or SNOMED CT-AU code.  For more information, see the [FHIR RESTful Search API](https://hl7.org/fhir/R4/http.html#search).
 
-
+Examples in AU Core do not demonstrate the url encoding [rules for special characters](https://hl7.org/fhir/R4/search.html#escaping) e.g. "\|".

--- a/input/pagecontent/general-guidance.md
+++ b/input/pagecontent/general-guidance.md
@@ -260,9 +260,9 @@ Example: Condition resource with coded condition, coded body site, laterality as
 
 ### Read/Search Syntax
 
-Searching resources is defined by the [FHIR RESTful API](https://hl7.org/fhir/R4/http.html) and included here for informative purposes. The [AU Core CapabilityStatements](capability-statements.html) document the server and client rules for the RESTful interactions described in this guide.
+Searching resources is defined by the [FHIR RESTful API](https://hl7.org/fhir/R4/http.html) and included here for informative purposes. The [AU Core CapabilityStatements](capability-statements.html) document the server and client rules for the RESTful interactions described in this guide. Examples in AU Core do not demonstrate the url encoding [rules for special characters](https://hl7.org/fhir/R4/search.html#escaping) e.g. "\|".
 
-All the search interactions in this guide use the `GET` command with the following syntax:
+All the search interaction examples in this guide use the HTTP GET method with the following syntax:
 
  **`GET [base]/[Resource-type]?[parameter1]{:m1|m2|...}={c1|c2|...}[value1{,value2,...}]{&[parameter2]{:m1|m2|...}={c1|c2|...}[value1{,value2,...}]&...}`**
 

--- a/input/pagecontent/medicine-information.md
+++ b/input/pagecontent/medicine-information.md
@@ -18,9 +18,9 @@ The guidance below addresses how medicinal product identification can be structu
 
 ### Medicinal Product Identification
 
-For extemporaneous medications, the medication code element is the primary mechanism to identify a medicine. In this case, a list of ingredients including strength and form is recommended to be provided as text in the medication code element e.g. Medication.code.text or MedicationRequest.medicationCodeableConcept.text.
+For extemporaneous medications, the medication code element is the primary mechanism to identify a medicine. In this case, a list of ingredients including strength and form is recommended to be provided as text in the medication code element e.g. `Medication.code.text` or `MedicationRequest.medicationCodeableConcept.text`.
 
-For non-extemporaneous medications, the medication code element is the primary mechanism to identify a medicine. In this case, information identifying the medicinal product including strength and form is recommended to be provided as a code from a terminology in the medication code element, e.g. Medication.code.coding or MedicationRequest.medicationCodeableConcept.coding, and the description of the medicinal product as presented to the user is provided in the text e.g. Medication.code.text or MedicationRequest.medicationCodeableConcept.text. 
+For non-extemporaneous medications, the medication code element is the primary mechanism to identify a medicine. In this case, information identifying the medicinal product including strength and form is recommended to be provided as a code from a terminology in the medication code element, e.g. `Medication.code.coding` or `MedicationRequest.medicationCodeableConcept.coding`, and the description of the medicinal product as presented to the user is provided in the text e.g. `Medication.code.text` or `MedicationRequest.medicationCodeableConcept.text`. 
 
 Australian Medicines Terminology (AMT) is the national terminology for identification and naming of medicines in clinical systems for Australia. 
 The AMT is published monthly to include new items on the Australian Register of Therapeutic Goods from the TGA, as well as items listed on the Pharmaceutical Benefits Scheme. 

--- a/input/pagecontent/medicine-information.md
+++ b/input/pagecontent/medicine-information.md
@@ -18,9 +18,9 @@ The guidance below addresses how medicinal product identification can be structu
 
 ### Medicinal Product Identification
 
-For extemporaneous medications, it is expected the medication code is the primary mechanism to identify a medicine. In this case, a text only list of ingredients may be supplied or may be coded using a medicines terminology.
+For extemporaneous medications, the medication code element is the primary mechanism to identify a medicine. In this case, a list of ingredients including strength and form is recommended to be provided as text in the medication code element e.g. Medication.code.text or MedicationRequest.medicationCodeableConcept.text.
 
-For non-extemporaneous medications, the medication code (or set of codes) is the mandatory primary mechanism to identify a medicine and its defining attributes (by terminology lookup) including form and strength. 
+For non-extemporaneous medications, the medication code element is the primary mechanism to identify a medicine. In this case, information identifying the medicinal product including strength and form is recommended to be provided as a code from a terminology in the medication code element, e.g. Medication.code.coding or MedicationRequest.medicationCodeableConcept.coding, and the description of the medicinal product as presented to the user is provided in the text e.g. Medication.code.text or MedicationRequest.medicationCodeableConcept.text. 
 
 Australian Medicines Terminology (AMT) is the national terminology for identification and naming of medicines in clinical systems for Australia. 
 The AMT is published monthly to include new items on the Australian Register of Therapeutic Goods from the TGA, as well as items listed on the Pharmaceutical Benefits Scheme. 


### PR DESCRIPTION
Fix for [FHIR-47194](https://jira.hl7.org/browse/FHIR-47194) & [FHIR-46740](https://jira.hl7.org/browse/FHIR-46740) - Read/Search Syntax guidance page:
* Add text regarding examples not demonstrating url encoding for special characters
* Replace "All the search interactions in this guide use the GET command with the following syntax:" with ""All the search interaction examples in this guide use the HTTP GET method with the following syntax:"
* Change log entry

Fix for [FHIR-46741](https://jira.hl7.org/browse/FHIR-46741) & [FHIR-46742](https://jira.hl7.org/browse/FHIR-46742) - Medicinal Product Identification guidance:
* Change text describing medicinal product identification of extemp and non-extemp medications
* Change log entry