### PR TITLE
Text changes to Profiles and Extensions, Terminology, Comparison and Procedure intro

### DIFF
--- a/input/intro-notes/StructureDefinition-au-core-procedure-intro.md
+++ b/input/intro-notes/StructureDefinition-au-core-procedure-intro.md
@@ -11,8 +11,7 @@ The following are supported usage scenarios for this profile:
 - `Procedure.category` provides an efficient way of supporting system interactions, e.g. restricting searches. Implementers need to understand that data categorisation is somewhat subjective. The categorisation applied by the source may not align with a receiver’s expectations.
 - The use of coding can vary significantly across systems, requesters need to understand that they may encounter codes they do not recognise and be prepared to handle those resources appropriately. Responders **SHOULD** populate `Procedure.code.text` and/or `Procedure.code.coding.display` so that requesters can at least display the procedure even if the requester does not recognise the code supplied.
 - `Procedure.code` contains the identification of the procedure which may include body site information. Where a system has information not supported by the coding in `Procedure.code.coding` (e.g. body site, laterality and other qualification of procedure coding terms) that information **SHOULD** be supplied in `Procedure.code.text`
-- In an exchange with the My Health Record system `Procedure.status` is "completed"
 - The Procedure resource can represent a clinical indication with `Procedure.reasonCode`, or a reference with `Procedure.reasonReference` to a Condition or other resource.
   - Although both are marked as *Must Support*, responders are not required to support both a code and a reference, but they **SHALL** support *at least one* of these elements
   - A requester **SHALL** support both elements
-- A procedure including an implantable device should use `Procedure.focalDevice` with a reference to a Device resource
+- A procedure including an implantable device is recommended to use `Procedure.focalDevice` with a reference to a Device resource

--- a/input/pagecontent/comparison.md
+++ b/input/pagecontent/comparison.md
@@ -874,7 +874,7 @@ The following US Core profile(s) contain additional requirements. Implementers a
 AU Core compliant resources are compliant with US Core requirements for Missing Data.
 
 ##### Suppressed Data
-US Core does not include requirements for Suppressed Data.
+AU Core compliant resources are compliant with US Core requirements for Suppressed Data.
 
 ##### Additional profiles 
 This version of AU Core has no equivalent profile for the following US Core profiles:

--- a/input/pagecontent/profiles-and-extensions.md
+++ b/input/pagecontent/profiles-and-extensions.md
@@ -15,7 +15,7 @@ The following profiles and have been defined for this implementation guide.
 
 ### Extensions
 
-All extensions used in this guide are defined in the [FHIR Extensions Pack](http://hl7.org/fhir/extensions/ImplementationGuide/hl7.fhir.uv.extensions) or [AU Base](http://build.fhir.org/ig/hl7au/au-fhir-base/profiles-and-extensions.html#extensions).
+All extensions used in this guide are defined in the FHIR Extensions Pack or [AU Base](http://build.fhir.org/ig/hl7au/au-fhir-base/profiles-and-extensions.html#extensions).
 
 The following extensions are marked with *Must Support* in this implementation guide:
 * [Individual Pronouns](http://hl7.org/fhir/StructureDefinition/individual-pronouns) in [AU Core Patient](StructureDefinition-au-core-patient.html)

--- a/input/pagecontent/profiles-and-extensions.md
+++ b/input/pagecontent/profiles-and-extensions.md
@@ -15,9 +15,9 @@ The following profiles and have been defined for this implementation guide.
 
 ### Extensions
 
-All extensions used in this guide are defined in the base FHIR specification or [AU Base](http://build.fhir.org/ig/hl7au/au-fhir-base/profiles-and-extensions.html#extensions).
+All extensions used in this guide are defined in the [FHIR Extensions Pack](http://hl7.org/fhir/extensions/ImplementationGuide/hl7.fhir.uv.extensions) or [AU Base](http://build.fhir.org/ig/hl7au/au-fhir-base/profiles-and-extensions.html#extensions).
 
-The following extension are marked with *Must Support* in this implementation guide:
+The following extensions are marked with *Must Support* in this implementation guide:
 * [Individual Pronouns](http://hl7.org/fhir/StructureDefinition/individual-pronouns) in [AU Core Patient](StructureDefinition-au-core-patient.html)
 * [Individual Gender Identity](http://hl7.org/fhir/StructureDefinition/individual-genderIdentity) in [AU Core Patient](StructureDefinition-au-core-patient.html)
 

--- a/input/pagecontent/profiles-and-extensions.md
+++ b/input/pagecontent/profiles-and-extensions.md
@@ -17,7 +17,7 @@ The following profiles and have been defined for this implementation guide.
 
 All extensions used in this guide are defined in the FHIR Extensions Pack or [AU Base](http://build.fhir.org/ig/hl7au/au-fhir-base/profiles-and-extensions.html#extensions).
 
-The following extension are marked with *Must Support* in this implementation guide:
+The following extensions are marked with *Must Support* in this implementation guide:
 * [Australian Indigenous Status](https://build.fhir.org/ig/hl7au/au-fhir-base/StructureDefinition-indigenous-status.html) in [AU Core Patient](StructureDefinition-au-core-patient.html)
 * [Individual Pronouns](http://hl7.org/fhir/StructureDefinition/individual-pronouns) in [AU Core Patient](StructureDefinition-au-core-patient.html)
 * [Individual Gender Identity](http://hl7.org/fhir/StructureDefinition/individual-genderIdentity) in [AU Core Patient](StructureDefinition-au-core-patient.html)

--- a/input/pagecontent/terminology.md
+++ b/input/pagecontent/terminology.md
@@ -138,12 +138,3 @@ The list below shows the code systems used in the value sets above.
 |[v3 Code System ObservationInterpretation](https://hl7.org/fhir/R4/v3/ObservationInterpretation/cs.html)|[Observation Category Codes](https://hl7.org/fhir/R4/valueset-observation-interpretation.html)|FHIR|
 |[v3 Code System ParticipationType](https://hl7.org/fhir/R4/v3/ParticipationType/cs.html)|[Participant type](https://hl7.org/fhir/R4/valueset-encounter-participant-type.html)|FHIR|
 {:.grid}
-
-
-### Concept Maps
-
-See the [FHIR terminology section]({{site.data.fhir.path}}terminologies-conceptmaps.html) for a complete discussion on concept maps and a list of concept map names used in FHIR.  Most concept maps relevant to this guide are defined in the base FHIR specification or [AU Base](https://build.fhir.org/ig/hl7au/au-fhir-base/terminology.html). The following concept maps are unique to this guide.
-
-**Concept maps published in the NCTS**
-- [ObservationStatus Result Available to v2 OBSERVATION RESULT STATUS](https://healthterminologies.gov.au/fhir/ConceptMap/observstatus-result-avail-to-v2-obs-result-status-1)
-- [v2 OBSERVATION RESULT STATUS to ObservationStatus Result Available](https://healthterminologies.gov.au/fhir/ConceptMap/v2-obs-result-status-to-observstatus-result-avail-1)


### PR DESCRIPTION
Fix for [FHIR-47022](https://jira.hl7.org/browse/FHIR-47022)
* Change text to reference FHIR Extensions Pack instead of base FHIR spec
* Fix typo "The following extension are..." to extensions

Fix for [FHIR-46882](https://jira.hl7.org/browse/FHIR-46882)
* Delete Concept Map section from Terminology page

Fix for [FHIR-46874](https://jira.hl7.org/browse/FHIR-46874)
* Change text from "US Core does not include requirements for Suppressed Data." to "AU Core compliant resources are compliant with US Core requirements for Suppressed Data."

Fix for [FHIR-46738](https://jira.hl7.org/browse/FHIR-46738)
* Delete "In an exchange with the My Health Record system Procedure.status is "completed"
* Change 'should' to 'is recommended to use' in "A procedure including an implantable device should..."