### PR TITLE
QA fixes

### DIFF
--- a/input/intro-notes/StructureDefinition-au-core-bodyheight-intro.md
+++ b/input/intro-notes/StructureDefinition-au-core-bodyheight-intro.md
@@ -1,3 +1,5 @@
+See [Comparison with other national and international IGs](comparison.html) for a comparison between AU Core profiles and profiles in other implementation guides.
+
 ### Usage scenarios
 
 The following are supported usage scenarios for this profile:
@@ -5,19 +7,5 @@ The following are supported usage scenarios for this profile:
 - Query for observations of body height associated with a patient
 - Record or update an observation of body height associated with a patient
 
-
-### Comparison with other national and international IGs
-
-A resource conforming to this profile is conformant to:
-- [observation-bodyheight](http://hl7.org/fhir/R4/observation-bodyheight.html)
-  - and therefore conformant to [International Patient Summary](http://build.fhir.org/ig/HL7/fhir-ips)
-- [IPA-Observation](https://build.fhir.org/ig/HL7/fhir-ipa/StructureDefinition-ipa-observation.html)
-- [US Core Body Height](http://hl7.org/fhir/us/core/StructureDefinition/us-core-body-height)
-
-Conformance in reverse is not guaranteed, i.e. a resource conforming to [International Patient Access](https://build.fhir.org/ig/HL7/fhir-ipa), [International Patient Summary](http://build.fhir.org/ig/HL7/fhir-ips), or [US Core](http://hl7.org/fhir/us/core) **MAY NOT** conform to AU Core.
-
-
 ### Profile specific implementation guidance
-
-
 {% include observation_vitalsigns_guidance.md -%}

--- a/input/intro-notes/StructureDefinition-au-core-bodytemp-intro.md
+++ b/input/intro-notes/StructureDefinition-au-core-bodytemp-intro.md
@@ -1,21 +1,11 @@
+See [Comparison with other national and international IGs](comparison.html) for a comparison between AU Core profiles and profiles in other implementation guides.
+
 ### Usage scenarios
 
 The following are supported usage scenarios for this profile:
 
 - Query for observations of body temperature associated with a patient
 - Record or update an observation of body temperature associated with a patient
-
-
-### Comparison with other national and international IGs
-
-A resource conforming to this profile is conformant to:
-- [observation-bodytemp](http://hl7.org/fhir/R4/observation-bodytemp.html)
-  - and therefore conformant to [International Patient Summary](http://build.fhir.org/ig/HL7/fhir-ips)
-- Conformant to [IPA-Observation](https://build.fhir.org/ig/HL7/fhir-ipa/StructureDefinition-ipa-observation.html)
-- [US Core Body Temperature](http://hl7.org/fhir/us/core/StructureDefinition/us-core-body-temperature)
-
-Conformance in reverse is not guaranteed, i.e. a resource conforming to [International Patient Access](https://build.fhir.org/ig/HL7/fhir-ipa), [International Patient Summary](http://build.fhir.org/ig/HL7/fhir-ips), or [US Core](http://hl7.org/fhir/us/core) **MAY NOT** conform to AU Core.
-
 
 ### Profile specific implementation guidance
 {% include observation_vitalsigns_guidance.md -%}

--- a/input/intro-notes/StructureDefinition-au-core-resprate-intro.md
+++ b/input/intro-notes/StructureDefinition-au-core-resprate-intro.md
@@ -1,21 +1,11 @@
+See [Comparison with other national and international IGs](comparison.html) for a comparison between AU Core profiles and profiles in other implementation guides.
+
 ### Usage scenarios
 
 The following are supported usage scenarios for this profile:
 
 - Query for observations of respiration rate associated with a patient
 - Record or update an observation of respiration rate associated with a patient
-
-
-### Comparison with other national and international IGs
-
-A resource conforming to this profile is conformant to:
-- [observation-resprate](http://hl7.org/fhir/us/core/StructureDefinition/us-core-respiratory-rate)
-  - and therefore conformant to [International Patient Summary](http://build.fhir.org/ig/HL7/fhir-ips)
-- [IPA-Observation](https://build.fhir.org/ig/HL7/fhir-ipa/StructureDefinition-ipa-observation.html)
-- [US Core Respiratory Rate](http://hl7.org/fhir/us/core/StructureDefinition/us-core-heart-rate)
-
-Conformance in reverse is not guaranteed, i.e. a resource conforming to [International Patient Access](https://build.fhir.org/ig/HL7/fhir-ipa), [International Patient Summary](http://build.fhir.org/ig/HL7/fhir-ips), or [US Core](http://hl7.org/fhir/us/core) **MAY NOT** conform to AU Core.
-
 
 ### Profile specific implementation guidance
 {% include observation_vitalsigns_guidance.md -%}

--- a/input/pagecontent/general-guidance.md
+++ b/input/pagecontent/general-guidance.md
@@ -114,7 +114,7 @@ Example: Patient resource with interpreter required and language is known
 When exchanging `Procedure` and `Condition` resources using AU Core profiles there may be a need to represent a relevant body site and associated laterality using `CodeableConcept` elements. In FHIR, body site and associated laterality can be recorded in various ways and implementers are encourage to consider the following points when implementing:
 
 * The `bodySite` element is not *Must Support* in AU Core profiles, there is no expectation to fill or meaningfully consume this element.
-* The `CodeableConcept.text` element is system populated and may reflect more specific detail than the `CodeableConcept`.coding concepts provided.
+* The `CodeableConcept.text` element is system populated and may reflect more specific detail than the `CodeableConcept.coding` concepts provided.
 
 AU Core provides the following guidance for what to do in each of the following scenarios:
 


### PR DESCRIPTION
QA fixes: 
- Remove Comparison with other national and international IGs from the intro pages in AU Core Body Temperature, AU Core Body Height, and AU Core Respiration Rate, and add link to the Comparison page
- General Guidance page - fix formatting `CodeableConcept.coding`