### PR TITLE
Change Organization name search parameter from SHOULD to SHALL (FHIR-47109)

### DIFF
--- a/input/intro-notes/StructureDefinition-au-core-organization-notes.md
+++ b/input/intro-notes/StructureDefinition-au-core-organization-notes.md
@@ -13,14 +13,14 @@
         <td><code>token</code></td>
         <td>The requester <b>SHALL</b> provide both the system and code values. The responder <b>SHALL</b> support both. <br/><br/> The requester <b>SHOULD</b> support search using HPI-O and ABN identifiers as defined in the profile. The responder <b>SHOULD</b> support search using the using HPI-O and ABN identifiers as defined in the profile.</td>
   </tr>
-  <tr>
-        <td>address</td>
-        <td><b>SHOULD</b></td>
+    <tr>
+        <td>name</td>
+        <td><b>SHALL</b></td>
         <td><code>string</code></td>
         <td></td>
   </tr>
   <tr>
-        <td>name</td>
+        <td>address</td>
         <td><b>SHOULD</b></td>
         <td><code>string</code></td>
         <td></td>
@@ -49,6 +49,15 @@ The following search parameters **SHALL** be supported:
 
     *Implementation Notes:* Fetches a bundle containing any Organization resources matching the identifier ([how to search by token](http://hl7.org/fhir/R4/search.html#token))
 
+1. **SHALL** support searching based on text name using the **[`name`](https://hl7.org/fhir/R4/organization.html#search)** search parameter:
+    
+    `GET [base]/Organization?name=[string]`
+
+    Example:
+    
+      1. GET [base]/Organization?name=Hospital
+
+    *Implementation Notes:* Fetches a bundle of all Organization resources matching the name ([how to search by string](http://hl7.org/fhir/R4/search.html#string))
 
 #### Optional Search Parameters:
 
@@ -63,16 +72,6 @@ The following search parameters **SHOULD** be supported:
       1. GET [base]/Organization?address=QLD
 
     *Implementation Notes:* Fetches a bundle of all Organization resources matching the address ([how to search by string](http://hl7.org/fhir/R4/search.html#string))
-    
-1. **SHOULD** support searching based on text name using the **[`name`](https://hl7.org/fhir/R4/organization.html#search)** search parameter:
-    
-    `GET [base]/Organization?name=[string]`
-
-    Example:
-    
-      1. GET [base]/Organization?name=Hospital
-
-    *Implementation Notes:* Fetches a bundle of all Organization resources matching the name ([how to search by string](http://hl7.org/fhir/R4/search.html#string))
     
 1. **SHOULD** support searching using the **[`_id`](https://hl7.org/fhir/R4/organization.html#search)** search parameter:
     

--- a/input/pagecontent/changes.md
+++ b/input/pagecontent/changes.md
@@ -11,6 +11,7 @@ This change log documents the significant updates and resolutions implemented fr
 - Changed the Observation  search parameter 'patient' from SHALL to MAY [FHIR-47171](https://jira.hl7.org/browse/FHIR-47171)
 - Removed the requirement for including an offset in the Patient 'birthdate' search parameter [FHIR-47150](https://jira.hl7.org/browse/FHIR-47150)
 - Updated requirement for AU Core Requester to mandate both system and code values for identifier search parameters on Location, Organization, Practitioner and PractitionerRole [FHIR-46782](https://jira.hl7.org/browse/FHIR-46782)
+- Changed the Organization search parameter 'name' from SHOULD to SHALL [FHIR-47109](https://jira.hl7.org/browse/FHIR-47109)
 
 ###  Release 1.0.0-ballot
 - Publication date: 2024-08-05

--- a/input/pagecontent/changes.md
+++ b/input/pagecontent/changes.md
@@ -11,8 +11,8 @@ This change log documents the significant updates and resolutions implemented fr
 - Changed the Observation  search parameter 'patient' from SHALL to MAY [FHIR-47171](https://jira.hl7.org/browse/FHIR-47171)
 - Removed the requirement for including an offset in the Patient 'birthdate' search parameter [FHIR-47150](https://jira.hl7.org/browse/FHIR-47150)
 - Updated requirement for AU Core Requester to mandate both system and code values for identifier search parameters on Location, Organization, Practitioner and PractitionerRole [FHIR-46782](https://jira.hl7.org/browse/FHIR-46782)
-- Changed the Organization search parameter 'name' from SHOULD to SHALL [FHIR-47109](https://jira.hl7.org/browse/FHIR-47109)
-- Changed the Location search parameter 'address' from SHALL to SHOULD [FHIR-47107](https://jira.hl7.org/browse/FHIR-47107)
+- Changed the Organization 'name' search parameter from SHOULD to SHALL [FHIR-47109](https://jira.hl7.org/browse/FHIR-47109)
+- Changed the Location 'address' search parameter from SHALL to SHOULD [FHIR-47107](https://jira.hl7.org/browse/FHIR-47107)
 
 ###  Release 1.0.0-ballot
 - Publication date: 2024-08-05

--- a/input/resources/au-core-requester.xml
+++ b/input/resources/au-core-requester.xml
@@ -1214,7 +1214,7 @@
 </searchParam>
 <searchParam>
 <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
-<valueCode value="SHOULD"/>
+<valueCode value="SHALL"/>
 </extension>
 <name value="name"/>
 <definition value="http://hl7.org/fhir/SearchParameter/Organization-name"/>

--- a/input/resources/au-core-responder.xml
+++ b/input/resources/au-core-responder.xml
@@ -1205,7 +1205,7 @@
 </searchParam>
 <searchParam>
 <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
-<valueCode value="SHOULD"/>
+<valueCode value="SHALL"/>
 </extension>
 <name value="name"/>
 <definition value="http://hl7.org/fhir/SearchParameter/Organization-name"/>


### PR DESCRIPTION
Fix for [FHIR-47109](https://jira.hl7.org/browse/FHIR-47109)

* Change Organization name search param from SHOULD to SHALL in requester and responder CapStats, Organization notes (table and example)
* Change log entry