### PR TITLE
MedRequest search parameters: change patient+intent & patient+intent+status to SHOULD, add patient+status as SHALL (FHIR-47073)

### DIFF
--- a/input/intro-notes/StructureDefinition-au-core-medicationrequest-notes.md
+++ b/input/intro-notes/StructureDefinition-au-core-medicationrequest-notes.md
@@ -13,15 +13,21 @@
         <td><code>reference</code></td>
         <td>The requester <b>SHALL</b> provide at least an id value and <b>MAY</b> provide both the Type and id values. The responder <b>SHALL</b> support both.</td>
   </tr>
-  <tr>
-        <td>patient+intent</td>
+    <tr>
+        <td>patient+status</td>
         <td><b>SHALL</b></td>
         <td><code>reference</code>+<code>token</code></td>
          <td></td>
   </tr>
   <tr>
+        <td>patient+intent</td>
+        <td><b>SHOULD</b></td>
+        <td><code>reference</code>+<code>token</code></td>
+         <td></td>
+  </tr>
+  <tr>
         <td>patient+intent+status</td>
-        <td><b>SHALL</b></td>
+        <td><b>SHOULD</b></td>
         <td><code>reference</code>+<code>token</code>+<code>token</code></td>
          <td></td>
   </tr>
@@ -85,34 +91,20 @@ The following search parameters and search parameter combinations **SHALL** be s
 
     *Implementation Notes:* Fetches a bundle of all MedicationRequest resources for the specified patient ([how to search by reference](http://hl7.org/fhir/R4/search.html#reference) and [how to search by token](http://hl7.org/fhir/R4/search.html#token))
 
-1. **SHALL** support searching using the combination of the **[`patient`](https://hl7.org/fhir/R4/medicationrequest.html#search)** and **[`intent`](https://hl7.org/fhir/R4/medicationrequest.html#search)** search parameters:
-    - **SHOULD** support these **[`_include`](http://hl7.org/fhir/R4/search.html#include)** parameters: `MedicationRequest:medication`
-    - **SHOULD** support chained searching of patient canonical identifier `patient.identifier` (e.g. `patient.identifier=[system|][code]`)
-
-
-    `GET [base]/MedicationRequest?patient={Type/}[id]&intent={system|}[code]`
-
-    Example:
-    
-      1. GET [base]/MedicationRequest?patient=5678&amp;intent=order
-
-    *Implementation Notes:* Fetches a bundle of all MedicationRequest resources for the specified patient and intent ([how to search by reference](http://hl7.org/fhir/R4/search.html#reference) and [how to search by token](http://hl7.org/fhir/R4/search.html#token))
-
-1. **SHALL** support searching using the combination of the **[`patient`](https://hl7.org/fhir/R4/medicationrequest.html#search)** and **[`intent`](https://hl7.org/fhir/R4/medicationrequest.html#search)** and **[`status`](https://hl7.org/fhir/R4/medicationrequest.html#search)** search parameters:
+1. **SHALL** support searching using the combination of the **[`patient`](https://hl7.org/fhir/R4/medicationrequest.html#search)** and **[`status`](https://hl7.org/fhir/R4/medicationrequest.html#search)** search parameters:
     - **SHOULD** support these **[`_include`](http://hl7.org/fhir/R4/search.html#include)** parameters: `MedicationRequest:medication`
     - **SHOULD** support chained searching of patient canonical identifier `patient.identifier` (e.g. `patient.identifier=[system|][code]`)
     - **SHALL** support *[multipleOr](http://hl7.org/fhir/R4/searchparameter-definitions.html#SearchParameter.multipleOr)* search on `status` (e.g.`status={system|}[code],{system|}[code],...`)
 
 
-    `GET [base]/MedicationRequest?patient={Type/}[id]&intent={system|}[code]&status={system|}[code]{,{system|}[code],...}`
+    `GET [base]/MedicationRequest?patient={Type/}[id]&status={system|}[code]{,{system|}[code],...}`
 
     Example:
     
-      1. GET [base]/MedicationRequest?patient=5678&amp;intent=order&amp;status=active
-      1. GET [base]/MedicationRequest?patient=5678&amp;intent=order&amp;status=active&amp;_include=MedicationRequest:medication
+      1. GET [base]/MedicationRequest?patient=5678&amp;status=active
+      1. GET [base]/MedicationRequest?patient=5678&amp;status=active&amp;_include=MedicationRequest:medication
 
-    *Implementation Notes:* Fetches a bundle of all MedicationRequest resources for the specified patient and intent and status ([how to search by reference](http://hl7.org/fhir/R4/search.html#reference) and [how to search by token](http://hl7.org/fhir/R4/search.html#token))
-
+    *Implementation Notes:* Fetches a bundle of all MedicationRequest resources for the specified patient and status ([how to search by reference](http://hl7.org/fhir/R4/search.html#reference) and [how to search by token](http://hl7.org/fhir/R4/search.html#token))
 
 #### Optional Search Parameters
 
@@ -145,3 +137,31 @@ The following search parameters and search parameter combinations **SHOULD** be 
       1. GET [base]/MedicationRequest?patient=5678&amp;intent=order&amp;authoredon=ge2020-01-01T00:00:00Z
 
     *Implementation Notes:* Fetches a bundle of all MedicationRequest resources for the specified patient and intent and date ([how to search by reference](http://hl7.org/fhir/R4/search.html#reference) and [how to search by token](http://hl7.org/fhir/R4/search.html#token) and [how to search by date](http://hl7.org/fhir/R4/search.html#date))
+
+1. **SHOULD** support searching using the combination of the **[`patient`](https://hl7.org/fhir/R4/medicationrequest.html#search)** and **[`intent`](https://hl7.org/fhir/R4/medicationrequest.html#search)** search parameters:
+    - **SHOULD** support these **[`_include`](http://hl7.org/fhir/R4/search.html#include)** parameters: `MedicationRequest:medication`
+    - **SHOULD** support chained searching of patient canonical identifier `patient.identifier` (e.g. `patient.identifier=[system|][code]`)
+
+
+    `GET [base]/MedicationRequest?patient={Type/}[id]&intent={system|}[code]`
+
+    Example:
+    
+      1. GET [base]/MedicationRequest?patient=5678&amp;intent=order
+
+    *Implementation Notes:* Fetches a bundle of all MedicationRequest resources for the specified patient and intent ([how to search by reference](http://hl7.org/fhir/R4/search.html#reference) and [how to search by token](http://hl7.org/fhir/R4/search.html#token))
+
+1. **SHOULD** support searching using the combination of the **[`patient`](https://hl7.org/fhir/R4/medicationrequest.html#search)** and **[`intent`](https://hl7.org/fhir/R4/medicationrequest.html#search)** and **[`status`](https://hl7.org/fhir/R4/medicationrequest.html#search)** search parameters:
+    - **SHOULD** support these **[`_include`](http://hl7.org/fhir/R4/search.html#include)** parameters: `MedicationRequest:medication`
+    - **SHOULD** support chained searching of patient canonical identifier `patient.identifier` (e.g. `patient.identifier=[system|][code]`)
+    - **SHALL** support *[multipleOr](http://hl7.org/fhir/R4/searchparameter-definitions.html#SearchParameter.multipleOr)* search on `status` (e.g.`status={system|}[code],{system|}[code],...`)
+
+
+    `GET [base]/MedicationRequest?patient={Type/}[id]&intent={system|}[code]&status={system|}[code]{,{system|}[code],...}`
+
+    Example:
+    
+      1. GET [base]/MedicationRequest?patient=5678&amp;intent=order&amp;status=active
+      1. GET [base]/MedicationRequest?patient=5678&amp;intent=order&amp;status=active&amp;_include=MedicationRequest:medication
+
+    *Implementation Notes:* Fetches a bundle of all MedicationRequest resources for the specified patient and intent and status ([how to search by reference](http://hl7.org/fhir/R4/search.html#reference) and [how to search by token](http://hl7.org/fhir/R4/search.html#token))

--- a/input/pagecontent/changes.md
+++ b/input/pagecontent/changes.md
@@ -11,7 +11,7 @@ This change log documents the significant updates and resolutions implemented fr
 - Changed the Observation  search parameter 'patient' from SHALL to MAY [FHIR-47171](https://jira.hl7.org/browse/FHIR-47171)
 - Removed the requirement for including an offset in the Patient 'birthdate' search parameter [FHIR-47150](https://jira.hl7.org/browse/FHIR-47150)
 - Updated requirement for AU Core Requester to mandate both system and code values for identifier search parameters on Location, Organization, Practitioner and PractitionerRole [FHIR-46782](https://jira.hl7.org/browse/FHIR-46782)
-
+- Changed MedicationRequest search parameters 'patient+intent' and 'patient+intent+status' from SHALL to SHOULD; added new MedicationRequest search parameter 'patient+status' with required support of SHALL [FHIR-47073](https://jira.hl7.org/browse/FHIR-47073)
 ###  Release 1.0.0-ballot
 - Publication date: 2024-08-05
 - Publication status: Ballot

--- a/input/pagecontent/changes.md
+++ b/input/pagecontent/changes.md
@@ -11,7 +11,7 @@ This change log documents the significant updates and resolutions implemented fr
 - Changed the Observation  search parameter 'patient' from SHALL to MAY [FHIR-47171](https://jira.hl7.org/browse/FHIR-47171)
 - Removed the requirement for including an offset in the Patient 'birthdate' search parameter [FHIR-47150](https://jira.hl7.org/browse/FHIR-47150)
 - Updated requirement for AU Core Requester to mandate both system and code values for identifier search parameters on Location, Organization, Practitioner and PractitionerRole [FHIR-46782](https://jira.hl7.org/browse/FHIR-46782)
-- Changed MedicationRequest search parameters 'patient+intent' and 'patient+intent+status' from SHALL to SHOULD; added new MedicationRequest search parameter 'patient+status' with required support of SHALL [FHIR-47073](https://jira.hl7.org/browse/FHIR-47073)
+- Changed MedicationRequest search parameters 'patient+intent' and 'patient+intent+status' from SHALL to SHOULD, and added a new MedicationRequest search parameter 'patient+status' as a SHALL [FHIR-47073](https://jira.hl7.org/browse/FHIR-47073)
 - Changed the Location search parameter 'address' from SHALL to SHOULD [FHIR-47107](https://jira.hl7.org/browse/FHIR-47107)
 
 ###  Release 1.0.0-ballot

--- a/input/resources/au-core-requester.xml
+++ b/input/resources/au-core-requester.xml
@@ -775,7 +775,7 @@
 </extension>
 <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination">
 <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
-<valueCode value="SHALL"/>
+<valueCode value="SHOULD"/>
 </extension>
 <extension url="required">
 <valueString value="patient"/>
@@ -786,13 +786,24 @@
 </extension>
 <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination">
 <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
-<valueCode value="SHALL"/>
+<valueCode value="SHOULD"/>
 </extension>
 <extension url="required">
 <valueString value="patient"/>
 </extension>
 <extension url="required">
 <valueString value="intent"/>
+</extension>
+<extension url="required">
+<valueString value="status"/>
+</extension>
+</extension>
+<extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination">
+<extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+<valueCode value="SHALL"/>
+</extension>
+<extension url="required">
+<valueString value="patient"/>
 </extension>
 <extension url="required">
 <valueString value="status"/>

--- a/input/resources/au-core-responder.xml
+++ b/input/resources/au-core-responder.xml
@@ -767,7 +767,7 @@
 </extension>
 <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination">
 <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
-<valueCode value="SHALL"/>
+<valueCode value="SHOULD"/>
 </extension>
 <extension url="required">
 <valueString value="patient"/>
@@ -778,13 +778,24 @@
 </extension>
 <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination">
 <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
-<valueCode value="SHALL"/>
+<valueCode value="SHOULD"/>
 </extension>
 <extension url="required">
 <valueString value="patient"/>
 </extension>
 <extension url="required">
 <valueString value="intent"/>
+</extension>
+<extension url="required">
+<valueString value="status"/>
+</extension>
+</extension>
+<extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination">
+<extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+<valueCode value="SHALL"/>
+</extension>
+<extension url="required">
+<valueString value="patient"/>
 </extension>
 <extension url="required">
 <valueString value="status"/>


### PR DESCRIPTION
Fix for [FHIR-47073](https://jira.hl7.org/browse/FHIR-47073)

* Change patient+intent & patient+intent+status to SHOULD, add patient+status as SHALL in requester and responder CapStats and MedRequest resource notes (table and examples)
* Change log entry