### PR TITLE
Change Location address search parameter from SHALL to SHOULD (FHIR-47107)

### DIFF
--- a/input/intro-notes/StructureDefinition-au-core-location-notes.md
+++ b/input/intro-notes/StructureDefinition-au-core-location-notes.md
@@ -8,14 +8,14 @@
     <th>Requirements (when used alone or in combination)</th>
   </tr>
   <tr>
-        <td>address</td>
+        <td>name</td>
         <td><b>SHALL</b></td>
         <td><code>string</code></td>
         <td></td>
   </tr>
-  <tr>
-        <td>name</td>
-        <td><b>SHALL</b></td>
+    <tr>
+        <td>address</td>
+        <td><b>SHOULD</b></td>
         <td><code>string</code></td>
         <td></td>
   </tr>
@@ -49,19 +49,6 @@
 
 #### Mandatory Search Parameters
 
-The following search parameters **SHALL** be supported:
-
-1. **SHALL** support searching based on text address using the **[`address`](https://hl7.org/fhir/R4/location.html#search)** search parameter:
-    
-    `GET [base]/Location?address=[string]`
-
-    Example:
-    
-      1. GET [base]/Location?address=QLD
-      1. GET [base]/Location?address=QLD
-
-    *Implementation Notes:* Fetches a bundle of all Location resources matching the name ([how to search by string](http://hl7.org/fhir/R4/search.html#string))
-
 1. **SHALL** support searching based on text name using the **[`name`](https://hl7.org/fhir/R4/location.html#search)** search parameter:
     
     `GET [base]/Location?name=[string]`
@@ -76,6 +63,17 @@ The following search parameters **SHALL** be supported:
 #### Optional Search Parameters:
 
 The following search parameters **SHOULD** be supported:
+
+1. **SHOULD** support searching based on text address using the **[`address`](https://hl7.org/fhir/R4/location.html#search)** search parameter:
+    
+    `GET [base]/Location?address=[string]`
+
+    Example:
+    
+      1. GET [base]/Location?address=QLD
+      1. GET [base]/Location?address=QLD
+
+    *Implementation Notes:* Fetches a bundle of all Location resources matching the name ([how to search by string](http://hl7.org/fhir/R4/search.html#string))
 
 1. **SHOULD** support searching using the **[`address-city`](https://hl7.org/fhir/R4/location.html#search)** search parameter:
     

--- a/input/pagecontent/changes.md
+++ b/input/pagecontent/changes.md
@@ -11,6 +11,7 @@ This change log documents the significant updates and resolutions implemented fr
 - Changed the Observation  search parameter 'patient' from SHALL to MAY [FHIR-47171](https://jira.hl7.org/browse/FHIR-47171)
 - Removed the requirement for including an offset in the Patient 'birthdate' search parameter [FHIR-47150](https://jira.hl7.org/browse/FHIR-47150)
 - Updated requirement for AU Core Requester to mandate both system and code values for identifier search parameters on Location, Organization, Practitioner and PractitionerRole [FHIR-46782](https://jira.hl7.org/browse/FHIR-46782)
+- Changed the Location search parameter 'address' from SHALL to SHOULD [FHIR-47107](https://jira.hl7.org/browse/FHIR-47107)
 
 ###  Release 1.0.0-ballot
 - Publication date: 2024-08-05

--- a/input/resources/au-core-requester.xml
+++ b/input/resources/au-core-requester.xml
@@ -658,7 +658,7 @@
 </referencePolicy>
 <searchParam>
 <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
-<valueCode value="SHALL"/>
+<valueCode value="SHOULD"/>
 </extension>
 <name value="address"/>
 <definition value="http://hl7.org/fhir/SearchParameter/Location-address"/>

--- a/input/resources/au-core-responder.xml
+++ b/input/resources/au-core-responder.xml
@@ -652,7 +652,7 @@
 </referencePolicy>
 <searchParam>
 <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
-<valueCode value="SHALL"/>
+<valueCode value="SHOULD"/>
 </extension>
 <name value="address"/>
 <definition value="http://hl7.org/fhir/SearchParameter/Location-address"/>


### PR DESCRIPTION
Fix for [FHIR-47107](https://jira.hl7.org/browse/FHIR-47107)

* Changed Location address search parameter from SHALL to SHOULD in requester and responder CapStats and Location resource notes (table and example)
* Change log entry