### PR TITLE
Remove conformance for create, update, delete, vread, patch, history-instance from CapStats (FHIR-46060)

### DIFF
--- a/input/resources/au-core-requester.xml
+++ b/input/resources/au-core-requester.xml
@@ -540,12 +540,6 @@
 </extension>
 <code value="read"/>
 </interaction>
-<interaction>
-<extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
-<valueCode value="MAY"/>
-</extension>
-<code value="search-type"/>
-</interaction>
 <referencePolicy value="resolves">
 <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
 <valueCode value="SHOULD"/>

--- a/input/resources/au-core-responder.xml
+++ b/input/resources/au-core-responder.xml
@@ -533,12 +533,6 @@
 </extension>
 <code value="read"/>
 </interaction>
-<interaction>
-<extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
-<valueCode value="MAY"/>
-</extension>
-<code value="search-type"/>
-</interaction>
 <referencePolicy value="resolves">
 <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
 <valueCode value="SHOULD"/>


### PR DESCRIPTION
Fix for [FHIR-46060](https://jira.hl7.org/browse/FHIR-46060)

* Remove all instances of MAY support create, update, delete, vread, patch, history-instance from Responder and Requester Capstats.