### PR TITLE
Menu changes, Missing MS guidance change (FHIR-47184, FHIR-46951)

### DIFF
--- a/input/ig.xml
+++ b/input/ig.xml
@@ -751,34 +751,45 @@
 				</page>
 			</page>
 			<page>
-				<nameUrl value="profiles-and-extensions.html"/>
-				<title value="Profiles and Extensions"/>
-				<generation value="markdown"/>
-			</page>
-			<page>
-				<nameUrl value="search-parameters.html"/>
-				<title value="Search Parameters"/>
-				<generation value="markdown"/>
-			</page>
-			<page>
-				<nameUrl value="terminology.html"/>
-				<title value="Terminology"/>
-				<generation value="markdown"/>
-			</page>
-			<page>
 				<nameUrl value="security.html"/>
 				<title value="Security and Privacy"/>
 				<generation value="markdown"/>
 			</page>
 			<page>
-				<nameUrl value="capability-statements.html"/>
-				<title value="Capability Statements"/>
+				<nameUrl value="fhirartefacts.html"/>
+				<title value="FHIR Artefacts"/>
 				<generation value="markdown"/>
-			</page>
-			<page>
-				<nameUrl value="actors.html"/>
-				<title value="Actor Definitions"/>
-				<generation value="markdown"/>
+				<page>
+					<nameUrl value="artifacts.html"/>
+					<title value="Artefacts Summary"/>
+					<generation value="html"/>
+				</page>
+				<page>
+					<nameUrl value="profiles-and-extensions.html"/>
+					<title value="Profiles and Extensions"/>
+					<generation value="markdown"/>
+				</page>
+				<page>
+					<nameUrl value="search-parameters.html"/>
+					<title value="Search Parameters"/>
+					<generation value="markdown"/>
+				</page>
+				<page>
+					<nameUrl value="terminology.html"/>
+					<title value="Terminology"/>
+					<generation value="markdown"/>
+				</page>
+
+				<page>
+					<nameUrl value="capability-statements.html"/>
+					<title value="Capability Statements"/>
+					<generation value="markdown"/>
+				</page>
+				<page>
+					<nameUrl value="actors.html"/>
+					<title value="Actor Definitions"/>
+					<generation value="markdown"/>
+				</page>
 			</page>
 			<page>
 				<nameUrl value="examples.html"/>

--- a/input/ig.xml
+++ b/input/ig.xml
@@ -789,16 +789,16 @@
 				<nameUrl value="support.html"/>
 				<title value="Support"/>
 				<generation value="markdown"/>
-			</page>
-			<page>
-				<nameUrl value="downloads.html"/>
-				<title value="Downloads"/>
-				<generation value="markdown"/>
-			</page>
-			<page>
-				<nameUrl value="license.html"/>
-				<title value="License and Legal"/>
-				<generation value="markdown"/>
+				<page>
+					<nameUrl value="downloads.html"/>
+					<title value="Downloads"/>
+					<generation value="markdown"/>
+				</page>
+				<page>
+					<nameUrl value="license.html"/>
+					<title value="License and Legal"/>
+					<generation value="markdown"/>
+				</page>
 			</page>
 			<page>
 				<nameUrl value="changes.html"/>

--- a/input/includes/menu.xml
+++ b/input/includes/menu.xml
@@ -50,6 +50,9 @@
     </a>
     <ul class="dropdown-menu">
       <li>
+        <a href="artifacts.html">Artifacts Summary</a>
+      </li>
+      <li>
         <a href="profiles-and-extensions.html">Profiles and Extensions</a>
       </li>
       <li>

--- a/input/includes/menu.xml
+++ b/input/includes/menu.xml
@@ -50,7 +50,7 @@
     </a>
     <ul class="dropdown-menu">
       <li>
-        <a href="artifacts.html">Artifacts Summary</a>
+        <a href="artifacts.html">Artefacts Summary</a>
       </li>
       <li>
         <a href="profiles-and-extensions.html">Profiles and Extensions</a>

--- a/input/pagecontent/fhirartefacts.md
+++ b/input/pagecontent/fhirartefacts.md
@@ -1,0 +1,6 @@
+  - [Artefacts Summary](artifacts.html)
+  - [Profiles and Extensions](profiles-and-extensions.html)
+  - [Search Parameters](search-parameters.html)
+  - [Terminology](terminology.html)
+  - [Capability Statements](capability-statements.html)
+  - [Actor Definitions](actors.html)

--- a/input/pagecontent/general-requirements.md
+++ b/input/pagecontent/general-requirements.md
@@ -290,9 +290,11 @@ There are situations when information for a particular data element is missing a
 
 If the source system does not know the value for an optional element (minimum cardinality = 0), including elements labelled *Must Support*, the data element **SHALL** be omitted from the resource.  
 
+In AU Core Observation resources, `Observation.value` is conditionally mandatory. If the source system does not know the value for `Observation.value`, `Observation.dataAbsentReason` **SHALL** be used to capture the absence. Noting that other meaningful values can be captured in Observation.dataAbsentReason beyond `missing` or `suppressed`. 
+
 #### Missing Must Support and Mandatory Data
 
-If the data element is a mandatory element (minimum cardinality is > 0), the element **SHALL** be present *even if* the source system does not know the value or the reason the value is absent. The core specification provides guidance for what to do in this situation, which is summarised below.
+If the data element is a mandatory element (minimum cardinality is > 0), the element **SHALL** be present *even if* the source system does not know the value or the reason the value is absent.
 
 1.  For *non-coded* data elements where the applicable AU Core profile does not mandate a sub-element
     - use the [DataAbsentReason extension](http://hl7.org/fhir/R4/extension-data-absent-reason.html) 

--- a/input/pagecontent/general-requirements.md
+++ b/input/pagecontent/general-requirements.md
@@ -290,8 +290,6 @@ There are situations when information for a particular data element is missing a
 
 If the source system does not know the value for an optional element (minimum cardinality = 0), including elements labelled *Must Support*, the data element **SHALL** be omitted from the resource.  
 
-In AU Core Observation resources, `Observation.value` is conditionally mandatory. If the source system does not know the value for `Observation.value`, `Observation.dataAbsentReason` **SHALL** be used to capture the absence. Noting that other meaningful values can be captured in Observation.dataAbsentReason beyond `missing` or `suppressed`. 
-
 #### Missing Must Support and Mandatory Data
 
 If the data element is a mandatory element (minimum cardinality is > 0), the element **SHALL** be present *even if* the source system does not know the value or the reason the value is absent.

--- a/input/pagecontent/index.md
+++ b/input/pagecontent/index.md
@@ -98,7 +98,8 @@ This guide is divided into several pages which are listed at the top of each pag
   - [Comparison with other national and international IGs](comparison.html): This page provides comparison between AU Core profiles and other national, or international implementation guides.
   - [Future of AU Core](future.html): This page outlines the approach to developing AU Core and yearly update cycle.
 - [Security and Privacy](security.html): This page documents the AU Core general security and privacy requirements and recommendations.
-- [FHIR Artefacts](artifacts.html): These pages provide detailed descriptions and formal definitions for all the FHIR artefacts defined in this guide.
+- [FHIR Artefacts](fhirartefacts.html): These pages provide details of the FHIR artefacts defined in this guide.
+  - [Artefacts Summary](artifacts.html): This page provides detailed descriptions and formal definitions for all the FHIR artefacts defined in this guide.
   - [Profiles and Extensions](profiles-and-extensions.html): This page describes the profiles and extensions that are defined in this guide to exchange data. Each profile page includes a narrative description and guidance, formal definition and a "Notes" section that summarises the supported search transactions for each profile. Although the guidance typically focuses on the profiled elements, it may also may focus on un-profiled elements to aid with implementation.
   - [Search Parameters](search-parameters.html): This page lists the search parameters extended for use in this guide for use in AU Core operations.
   - [Terminology](terminology.html): This page lists the value sets and code systems supported in this guide.


### PR DESCRIPTION
Fix for [FHIR-47184](https://jira.hl7.org/browse/FHIR-47184)
* Change Support page to be parent of Downloads and License and Legal pages 
* Add Artefacts Summary to FHIR Artefacts drop down menu

Fix for [FHIR-46951](https://jira.hl7.org/browse/FHIR-46951)
* Remove "The core specification provides guidance for what to do in this situation" from Missing Must Support and Mandatory Data.

Additional changes out of scope of the above ballot tickets:
Changes made in AU Base on the Menu, Table of Contents and FHIR Artefacts navigation page to align with AU Base as per https://jira.hl7.org/browse/FHIR-47167
* Corrections to parent/child pages in Table of Contents
* Update Index page with FHIR Artefacts grouping page and Artefacts Summary as child page
* Add Artefact Summary to drop down menu