### PR TITLE
Refactor au-core-obs-01 expression in diagnostic and pathology result observations

### DIFF
--- a/input/resources/au-core-diagnosticresult-path.xml
+++ b/input/resources/au-core-diagnosticresult-path.xml
@@ -141,8 +141,8 @@
         <key value="au-core-obs-01"/>
         <severity value="error"/>
         <human value="Date shall be at least to day or, if not available, the Data Absent Reason extension shall be present"/>
-        <expression value="(($this is dateTime implies $this.toString().length() >= 10) and extension('http://hl7.org/fhir/StructureDefinition/data-absent-reason').value.exists().not()) xor ($this.hasValue().not() and extension('http://hl7.org/fhir/StructureDefinition/data-absent-reason').value.exists())"/>
-        <xpath value="((string-length(.) >= 10 and not(extension[@url='http://hl7.org/fhir/StructureDefinition/data-absent-reason']/value))) != (not(.) and extension[@url='http://hl7.org/fhir/StructureDefinition/data-absent-reason']/value)"/>
+        <expression value="(($this is dateTime implies $this.toString().length() >= 10) and extension('http://hl7.org/fhir/StructureDefinition/data-absent-reason').value.exists().not()) xor ($this is dateTime implies ($this.hasValue().not() and extension('http://hl7.org/fhir/StructureDefinition/data-absent-reason').value.exists()))"/>
+        <xpath value="((self::dateTime and string-length(.) >= 10 and not(extension[@url='http://hl7.org/fhir/StructureDefinition/data-absent-reason'])) xor (self::dateTime and not(.) and extension[@url='http://hl7.org/fhir/StructureDefinition/data-absent-reason']))"/>
         <source value="http://hl7.org.au/fhir/core/StructureDefinition/au-core-diagnosticresult-path"/>
       </constraint>
       <mustSupport value="true"/>

--- a/input/resources/au-core-diagnosticresult.xml
+++ b/input/resources/au-core-diagnosticresult.xml
@@ -138,8 +138,8 @@
         <key value="au-core-obs-01"/>
         <severity value="error"/>
         <human value="Date shall be at least to day or, if not available, the Data Absent Reason extension shall be present"/>
-        <expression value="(($this is dateTime implies $this.toString().length() >= 10) and extension('http://hl7.org/fhir/StructureDefinition/data-absent-reason').value.exists().not()) xor ($this.hasValue().not() and extension('http://hl7.org/fhir/StructureDefinition/data-absent-reason').value.exists())"/>
-        <xpath value="((string-length(.) >= 10 and not(extension[@url='http://hl7.org/fhir/StructureDefinition/data-absent-reason']/value))) != (not(.) and extension[@url='http://hl7.org/fhir/StructureDefinition/data-absent-reason']/value)"/>
+        <expression value="(($this is dateTime implies $this.toString().length() >= 10) and extension('http://hl7.org/fhir/StructureDefinition/data-absent-reason').value.exists().not()) xor ($this is dateTime implies ($this.hasValue().not() and extension('http://hl7.org/fhir/StructureDefinition/data-absent-reason').value.exists()))"/>
+        <xpath value="((self::dateTime and string-length(.) >= 10 and not(extension[@url='http://hl7.org/fhir/StructureDefinition/data-absent-reason'])) xor (self::dateTime and not(.) and extension[@url='http://hl7.org/fhir/StructureDefinition/data-absent-reason']))"/>
         <source value="http://hl7.org.au/fhir/core/StructureDefinition/au-core-diagnosticresult"/>
       </constraint>
       <mustSupport value="true"/>


### PR DESCRIPTION
Refactor au-core-obs-01 expression in AU Core Pathology Result Observation and AU Core Diagnostic Result Observation, resolving current [QA error]( https://build.fhir.org/ig/hl7au/au-fhir-core/qa.html#_scratch_repo_input_examples_observation-masked):
Observation​.effective​.ofType(Period) (l23​/c20) | error | Constraint failed: au-core-obs-01: 'Date shall be at least to day or, if not available, the Data Absent Reason extension shall be present' (defined in http://hl7.org.au/fhir/core/StructureDefinition/au-core-diagnosticresult)

FYI, see also 
:test_tube: [Test with FHIRPath-Lab](https://fhirpath-lab.com/FhirPath?parameters=N4IgpgHgDgTmDO8CWB7AdiAXCAFDgJAC4AWS8ABGeQCYCGhYAKkgLZiUtQA2SC5RpeADpCKAMqEYSNAHMcASiFcwskgvIA+ALzkAjAAZ55WmmrlIDNMnQ4A5MUKEomAPQviXAOxCUMGS4AzUhgXCRgAVwBjQnC4ABEwAOkkQlQ0FzpCWgBaWgAjeBVCbLhaeHRbRQA3Wi5wsCFIMkJ4BSE0FEIFIwhfcgISKipMplZ2Vm5eCgHBIWIygDVa+raOrqMTMwsVazQ7BydXdy8fP0Dg0MkomPjE5NT0DPoc-MK0YtLytEqhGrqGprwFrdeQgAA0IEi6AYEEIWHAAQCYGiSCqYHB4Fk0nR2AAVrQav0ABIAQQACgBJUEQhgwFjSFBcFAyACeYjAMDRMHhByg8CO8AAjky0EEkDASgAWIS0ABesTAAHcwAUUgh2mBCOdxRialJ8sp4FgANoAXQhcHKsUiYAAUl94cAADogS0oa1MFlQMAuzAugDyBQ5NQeaBdYJdSGovpdUHoxEt4S4xXpiGkMmyiSRKLR4ZdbCyvudIFgKCSyl9xpdvKOHm8vhkMvC2pCULglwi0QVCSSaBSaRctHC2TbYGy1CQtBkHSBSEiieT2TjJBdpoAvhGQED6OF4DGQL3annIfQwDJfCzK8WoRPZFeXfAWUCwCx9zW3LT6R0may5icGy4ADCKDUGAYhPgwLAuCgQacvQaQjqe54wJe4IujePpYC6XD5L49AXseE7wNwtCoX6IAADK4TA+EoS6a7rua6EgZhmDXiB6b3luEEvm+jjOG4TLSJEpwyMeGH7gAnJKADM+iSdkABM9FMSAMKEPuin6LoCkAHIoGiXDkMBMDoAS4q7uQZKAQASvRm7wOEeS4siGlYMWcBInAaA2vuZLwUU7goMq45gCYMhgEy9kulmrmomAcSnswbCafoWnZGlx4APqxTmCVJWMRYxbCOxpFxsRcHxhxuHWokth21zdncfahk8WS5EG7wlGFXzHn89TAaB+7hGgADWHSKmGIAMRuLr9WAg1hXkyjAT5YBQG5bHMbeYkmsWj7Pq+WEgO+LjwB0bDUEI0gBCgZ3ROJLGaQAbPokq6AArPo32EWQJFkS6+mEDQmquWA0bTap6n7kDIMMNE4PRSAayscaxbQ8djCCOQDBAuQC7A-MFC0OQqbILI-QjeNwVoEYIzkGW5BQlwygougKlrtNQA)

