### PR TITLE
QA fix for examples: identifier corrections, address correction

### DIFF
--- a/input/examples/allergyintolerance-lactose.xml
+++ b/input/examples/allergyintolerance-lactose.xml
@@ -33,9 +33,6 @@
   <recorder>
     <reference value="PractitionerRole/bobrester-bob-gp"/>
   </recorder>
-  <asserter>
-    <reference value="PractitionerRole/bobrester-bob-gp"/>
-  </asserter>
   <reaction>
     <manifestation>
       <coding>

--- a/input/examples/encounter-covid-admin-1.xml
+++ b/input/examples/encounter-covid-admin-1.xml
@@ -20,17 +20,18 @@
     <subject>
         <reference value="Patient/bennelong-anne"/>
 		<identifier>
-			<type>
-				<coding>
-					<system value="http://terminology.hl7.org/CodeSystem/v2-0203"/>
-					<code value="NI"/>
-					<display value="National unique individual identifier"/>
-				</coding>
-				<text value="IHI"/>
-			</type>
-			<system value="http://ns.electronichealth.net.au/id/hi/ihi/1.0"/>
-			<value value="8003608833357361"/>
-		</identifier>
+            <type>
+                <coding>
+                    <system value="http://terminology.hl7.org/CodeSystem/v2-0203"/>
+                    <code value="MR"/>
+                </coding>
+            </type>
+            <system value="http://mossypointmc.example.com/mrn/"/>
+            <value value="872038020"/>
+            <assigner>
+                <display value="Albion Hospital"/>
+            </assigner>
+        </identifier>
     </subject>
     <participant>
         <type>
@@ -44,15 +45,18 @@
             <reference value="PractitionerRole/bobrester-bob-gp"/> 
 			<identifier>
 				<type>
-					<coding>
-						<system value="http://terminology.hl7.org/CodeSystem/v2-0203"/>
-						<code value="NPI"/>
-						<display value="National provider identifier"/>
-					</coding>
-					<text value="HPI-I"/>
+				    <coding>
+                        <system value="http://terminology.hl7.org/CodeSystem/v2-0203"/>
+                        <code value="EI"/>
+                        <display value="Employee number"/>
+                    </coding>
+				    <text value="Employee Number"/>
 				</type>
-				<system value="http://ns.electronichealth.net.au/id/hi/hpii/1.0"/>
-				<value value="8003619900015717"/>
+				<system value="http://ns.electronichealth.net.au/id/abn-scoped/service-provider-individual/1.0/12345678901"/>
+				<value value="12345678"/>
+				<assigner>
+                    <display value="Bobrester Medical Center"/>
+				</assigner>
 			</identifier>
         </individual>
     </participant>

--- a/input/examples/patient-bennelong-anne.xml
+++ b/input/examples/patient-bennelong-anne.xml
@@ -16,12 +16,14 @@
         <type>
             <coding>
                 <system value="http://terminology.hl7.org/CodeSystem/v2-0203"/>
-                <code value="MC"/>
+                <code value="MR"/>
             </coding>
-            <text value="Medicare Number"/>
         </type>
-        <system value="http://ns.electronichealth.net.au/id/medicare-number"/>
-        <value value="6951449677"/>
+        <system value="http://mossypointmc.example.com/mrn/"/>
+        <value value="872038020"/>
+        <assigner>
+            <display value="Mossy Point Medical Centre"/>
+        </assigner>
     </identifier>
     <name>
         <use value="official"/>
@@ -39,10 +41,10 @@
     <birthDate value="1968-10-11"/>
     <address>
         <use value="home"/>
-        <line value="4 Brisbane Street"/>
-        <city value="Brisbane"/>
-        <state value="QLD"/>
-        <postalCode value="4112"/>
+        <line value="144 Otho Street"/>
+        <city value="Inverell"/>
+        <state value="NSW"/>
+        <postalCode value="2360"/>
         <country value="AU"/>
     </address>
     <communication>

--- a/input/examples/patient-wang-li.xml
+++ b/input/examples/patient-wang-li.xml
@@ -22,9 +22,9 @@
             <text value="Medical Record Number"/>
         </type>
         <system value="http://ns.electronichealth.net.au/id/hpio-scoped/medicalrecord/1.0/8003626566699734" />
-        <value value="2338189" />
+        <value value="22421441" />
         <assigner>
-            <display value="Large Metropolitan Hospital"/>
+            <display value="Mount Mitchell Private Hospital"/>
         </assigner>
     </identifier>
     <name>


### PR DESCRIPTION
1. Fix to replace national identifiers for local identifiers for personas that are not Services Australia
2. Fix for Anne Bennelong's address to match the preferred language
3. Remove asserter from example allergyintolerance-lactose to reduce the instances of 'asserter' in AU Core