### PR TITLE
Updates to IG & dependencies (#315)

### DIFF
--- a/input/ig.xml
+++ b/input/ig.xml
@@ -2,7 +2,7 @@
 <ImplementationGuide xmlns="http://hl7.org/fhir">
 	<id value="hl7.fhir.au.core"/>
 	<extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status">
-		<valueCode value="draft"/>
+		<valueCode value="trial-use"/>
 	</extension>
 	<extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
 		<valueInteger value="2"/>

--- a/input/ig.xml
+++ b/input/ig.xml
@@ -5,7 +5,7 @@
 		<valueCode value="draft"/>
 	</extension>
 	<extension url="http://hl7.org/fhir/StructureDefinition/structuredefinition-fmm">
-		<valueInteger value="1"/>
+		<valueInteger value="2"/>
 	</extension>
 	<url value="http://hl7.org.au/fhir/core/ImplementationGuide/hl7.fhir.au.core"/>
 	<version value="1.0.0-ci-build"/>
@@ -40,7 +40,7 @@
 	<dependsOn>
 		<uri value="http://hl7.org/fhir/smart-app-launch/ImplementationGuide/hl7.fhir.uv.smart-app-launch"/>
 		<packageId value="hl7.fhir.uv.smart-app-launch"/>
-		<version value="2.1.0"/>
+		<version value="current"/>
 	</dependsOn>
 	<dependsOn>
 		<uri value="http://hl7.org/fhir/uv/ipa/ImplementationGuide/hl7.fhir.uv.ipa"/>

--- a/input/resources/au-core-requester.xml
+++ b/input/resources/au-core-requester.xml
@@ -32,7 +32,7 @@
 <valueCode value="SHALL"/>
 </extension>
 </implementationGuide>
-<implementationGuide value="http://hl7.org/fhir/smart-app-launch/ImplementationGuide/hl7.fhir.uv.smart-app-launch|2.1.0">
+<implementationGuide value="http://hl7.org/fhir/smart-app-launch/ImplementationGuide/hl7.fhir.uv.smart-app-launch|2.2.0">
 <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
 <valueCode value="SHOULD"/>
 </extension>

--- a/input/resources/au-core-responder.xml
+++ b/input/resources/au-core-responder.xml
@@ -32,7 +32,7 @@
 <valueCode value="SHALL"/>
 </extension>
 </implementationGuide>
-<implementationGuide value="http://hl7.org/fhir/smart-app-launch/ImplementationGuide/hl7.fhir.uv.smart-app-launch|2.1.0">
+<implementationGuide value="http://hl7.org/fhir/smart-app-launch/ImplementationGuide/hl7.fhir.uv.smart-app-launch|2.2.0">
 <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
 <valueCode value="SHOULD"/>
 </extension>


### PR DESCRIPTION
Fixes #315. 

Changes:
1. Changed IG to be fmm=2, standards status=trial-use
2. Updated IG dependencies to the current version of Smart App Launch, and changed to v2.2.0 in both CapabilityStatements