### PR TITLE
Fixes for FHIR-46268 and FHIR-48749

### DIFF
--- a/input/pagecontent/changes.md
+++ b/input/pagecontent/changes.md
@@ -20,6 +20,8 @@ This change log documents the significant updates and resolutions implemented fr
   - added Must Support to MedicationStatement.dosage.text [FHIR-50101](https://jira.hl7.org/browse/FHIR-50101)
 - [AU Core Pathology Result Observation](StructureDefinition-au-core-diagnosticresult-path.html): 
   - Added profile-specific implementation guidance to see AU Core Diagnostic Result Observation profile for non imaging or pathology results  [FHIR-46889](https://jira.hl7.org/browse/FHIR-46889).
+- [AU Core Patient](StructureDefinition-au-core-patient.html): 
+  - removed the cardinality constraint on AU Medicare Card Number identifier, changing it from 0..1 to 0..*  [FHIR-46268](https://jira.hl7.org/browse/FHIR-46268).
 - [AU Core RelatedPerson](StructureDefinition-au-core-relatedperson.html):
   - added the new profile, including interaction support and replacing references to AU Base Related Person with AU Core RelatedPerson [FHIR-49745](https://jira.hl7.org/browse/FHIR-49745), [FHIR-49746](https://jira.hl7.org/browse/FHIR-49746), [FHIR-44600](https://jira.hl7.org/browse/FHIR-44600), [FHIR-49747](https://jira.hl7.org/browse/FHIR-49747).
 

--- a/input/resources/au-core-patient.xml
+++ b/input/resources/au-core-patient.xml
@@ -175,7 +175,6 @@
       </extension>
       <path value="Patient.identifier"/>
       <sliceName value="medicare"/>
-      <max value="1"/>
       <type>
         <code value="Identifier"/>
         <profile value="http://hl7.org.au/fhir/StructureDefinition/au-medicarecardnumber"/>

--- a/input/resources/searchparameter-au-core-clinical-patient.xml
+++ b/input/resources/searchparameter-au-core-clinical-patient.xml
@@ -8,7 +8,7 @@
     <name value="AUCoreClinicalPatient"/>
     <derivedFrom value="http://hl7.org/fhir/SearchParameter/clinical-patient"/>
     <status value="active"/>
-    <description value="A clinical patient **SHOULD** support patient.identifier. This AU Core SearchParameter extends the usage context of the&#xA;clinical-patient parameter&#xA; - multipleAnd&#xA; - multipleOr&#xA; - chain"/>
+    <description value="This SearchParameter describes the rules on the clinical-patient search parameter in AU Core. It is based on the core FHIR [clinical-patient](https://hl7.org/fhir/R4/searchparameter-registry.html#clinical-patient) search parameter and identifies the additional requirements when conforming to AU Core."/>
     <code value="patient"/>
     <base value="AllergyIntolerance"/>
     <base value="CarePlan"/>

--- a/input/resources/searchparameter-au-core-practitionerrole-practitioner.xml
+++ b/input/resources/searchparameter-au-core-practitionerrole-practitioner.xml
@@ -8,7 +8,7 @@
     <name value="AUCorePractitionerRolePractitioner"/>
     <derivedFrom value="http://hl7.org/fhir/SearchParameter/PractitionerRole-practitioner"/>
     <status value="active"/>
-    <description value="A practitioner role practitioner **SHOULD** support practitioner.identifier. NOTE: This AU Core SearchParameter extends the usage context of the&#xA;PractitionerRole-practitioner parameter&#xA; - multipleAnd&#xA; - multipleOr&#xA; - chain"/>
+    <description value="This SearchParameter describes the rules on the PractitionerRole-practitioner search parameter in AU Core. It is based on the core FHIR [PractitionerRole-practitioner](https://hl7.org/fhir/R4/practitionerrole.html#search) search parameter and identifies the additional requirements when conforming to AU Core."/>
     <code value="practitioner"/>
     <base value="PractitionerRole"/>
     <type value="reference"/>


### PR DESCRIPTION
This PR provides fixes for FHIR-46268 and FHIR-48749. 

Changes:
- [FHIR-46268](https://jira.hl7.org/browse/FHIR-46268)
   - removed cardinality constraint from the identifier slice in AU Core Patient StructureDefinition
   - change log
- [FHIR-48749](https://jira.hl7.org/browse/FHIR-48749)
   - updated AUCoreClinicalPatient and AUCorePractitionerRolePractitioner  SearchParameter descriptions 