### PR TITLE
 AU Core MedicationStatement & AU Core MedicationRequest: Remove redundant obligations from medicationReference (FHIR-50800)

### DIFF
--- a/input/intro-notes/StructureDefinition-au-core-medicationrequest-intro.md
+++ b/input/intro-notes/StructureDefinition-au-core-medicationrequest-intro.md
@@ -12,12 +12,11 @@ The following are supported usage scenarios for this profile:
 ### Profile specific implementation guidance
 - See the [Medicine Information](medicine-information.html) page for guidance on how medicinal product identification can be structured in FHIR conformant to AU Core.
 - When recording "self-prescribed" medication, `MedicationRequest.requester` references the Patient or RelatedPerson as the prescriber.
-- MedicationRequest resources can represent a medication using either a code with `MedicationRequest.medicationCodeableConcept`, or reference a [Medication](http://hl7.org/fhir/R4/medication.html) resource with `MedicationRequest.medicationReference`.
-  - Although both are marked as *Must Support*, responders are not required to support both a code and a reference, but they **SHALL** support *at least one* of these elements
-  - A requester **SHALL** support both elements
+- MedicationRequest resources can represent a medication using either a code as `MedicationRequest.medicationCodeableConcept`, or reference a [Medication](http://hl7.org/fhir/R4/medication.html) resource using `MedicationRequest.medicationReference`.
+  - Responders are not required to support both a code and a reference, but **SHALL** support *at least one* of these methods
   - When referencing a Medication resource, it is preferred the resource is [contained](http://hl7.org/fhir/R4/references.html#contained) but it may be an external resource
   - If an external reference to a Medication resource is used, the responder **SHALL** support the `_include` parameter for searching this element
-  - The requester **SHALL** support all method
+  - A requester **SHALL** support all methods
 - The MedicationRequest resource can represent the clinical indication as a code with `MedicationRequest.reasonCode`, or a reference with `MedicationRequest.reasonReference` to a Condition or other resource.
   - Although both are marked as *Must Support*, responders are not required to support both a code and a reference, but they **SHALL** support *at least one* of these elements
   - A requester **SHALL** support both elements  

--- a/input/intro-notes/StructureDefinition-au-core-medicationstatement-intro.md
+++ b/input/intro-notes/StructureDefinition-au-core-medicationstatement-intro.md
@@ -10,12 +10,11 @@ The following are supported usage scenarios for this profile:
 
 ### Profile specific implementation guidance
   - See the [Medicine Information](medicine-information.html) page for guidance on how medicinal product identification can be structured in FHIR conformant to AU Core.
-  - MedicationStatement resources can represent a medication using either a code with `MedicationStatement.medicationCodeableConcept`, or reference a [Medication](http://hl7.org/fhir/R4/medication.html) resource with `MedicationStatement.medicationReference`.
-    - Although both are marked as *Must Support*, responders are not required to support both a code and a reference, but they **SHALL** support *at least one* of these elements
-    - A requester **SHALL** support both elements
+  - MedicationStatement resources can represent a medication using either a code as `MedicationRequest.medicationCodeableConcept`, or reference a [Medication](http://hl7.org/fhir/R4/medication.html) resource using `MedicationRequest.medicationReference`.
+    - Responders are not required to support both a code and a reference, but they **SHALL** support *at least one* of these methods
     - When referencing a Medication resource, it is preferred the resource is [contained](http://hl7.org/fhir/R4/references.html#contained) but it may be an external resource
     - If an external reference to a Medication resource is used, the responder **SHALL** support the `_include` parameter for searching this element
-    - The requester **SHALL** support all methods
+    - A requester **SHALL** support all methods
   - The MedicationStatement resource can represent the clinical indication as a code with `MedicationStatement.reasonCode`, or a reference with `MedicationStatement.reasonReference` to a Condition or other resource.
     - Although both are marked as *Must Support*, responders are not required to support both a code and a reference, but they **SHALL** support *at least one* of these elements
     - A requester **SHALL** support both elements 

--- a/input/resources/au-core-medicationrequest.xml
+++ b/input/resources/au-core-medicationrequest.xml
@@ -153,22 +153,6 @@
       <mustSupport value="true"/>
     </element>
     <element id="MedicationRequest.medication[x]:medicationReference">
-      <extension url="http://hl7.org/fhir/StructureDefinition/obligation">
-        <extension url="code">
-          <valueCode value="SHALL:populate-if-known"/>
-        </extension>
-        <extension url="actor">
-          <valueCanonical value="http://hl7.org.au/fhir/core/ActorDefinition/au-core-actor-responder"/>
-        </extension>
-      </extension>
-      <extension url="http://hl7.org/fhir/StructureDefinition/obligation">
-        <extension url="code">
-          <valueCode value="SHALL:no-error"/>
-        </extension>
-        <extension url="actor">
-          <valueCanonical value="http://hl7.org.au/fhir/core/ActorDefinition/au-core-actor-requester"/>
-        </extension>
-      </extension>
       <path value="MedicationRequest.medication[x]"/>
       <sliceName value="medicationReference"/>
       <type>

--- a/input/resources/au-core-medicationstatement.xml
+++ b/input/resources/au-core-medicationstatement.xml
@@ -133,22 +133,6 @@
       <mustSupport value="true"/>
     </element>
     <element id="MedicationStatement.medication[x]:medicationReference">
-      <extension url="http://hl7.org/fhir/StructureDefinition/obligation">
-        <extension url="code">
-          <valueCode value="SHALL:populate-if-known"/>
-        </extension>
-        <extension url="actor">
-          <valueCanonical value="http://hl7.org.au/fhir/core/ActorDefinition/au-core-actor-responder"/>
-        </extension>
-      </extension>
-      <extension url="http://hl7.org/fhir/StructureDefinition/obligation">
-        <extension url="code">
-          <valueCode value="SHALL:no-error"/>
-        </extension>
-        <extension url="actor">
-          <valueCanonical value="http://hl7.org.au/fhir/core/ActorDefinition/au-core-actor-requester"/>
-        </extension>
-      </extension>
       <path value="MedicationStatement.medication[x]"/>
       <sliceName value="medicationReference"/>
       <type>


### PR DESCRIPTION
Fix for [FHIR-50800](https://jira.hl7.org/browse/FHIR-50800).

Changes:
- removed obligations from MedicationRequest.medicationReference and MedicationStatement.medicationReference
- updated implementation guidance for both profiles