### PR TITLE
QA Fix : remove short on Observation.effective[x] from AU Core Pathology Result Observation

### DIFF
--- a/input/resources/au-core-diagnosticresult-path.xml
+++ b/input/resources/au-core-diagnosticresult-path.xml
@@ -134,7 +134,6 @@
         </extension>
       </extension>
       <path value="Observation.effective[x]"/>
-      <short value="Time of specimen collection"/>
       <condition value="au-core-obs-02"/>
       <constraint>
         <key value="au-core-obs-02"/>


### PR DESCRIPTION
- remove short on Observation.effective[x] from AU Core Pathology Result Observation as it is inherited from AU Base.