### PR TITLE
Fix broken Zulip links in STU Notes

### DIFF
--- a/input/intro-notes/StructureDefinition-au-core-allergyintolerance-intro.md
+++ b/input/intro-notes/StructureDefinition-au-core-allergyintolerance-intro.md
@@ -18,6 +18,6 @@ The following are supported usage scenarios for this profile:
 
 The additional obligation for `AllergyIntolerance.onsetDateTime` for [AU Core Responder](ActorDefinition-au-core-actor-responder.html) is [SHOULD:populate](https://hl7.org/fhir/extensions/CodeSystem-obligation.html#obligation-SHOULD.58populate). There is no additional obligation for [AU Core Requester](ActorDefinition-au-core-actor-requester.html), the obligation of [SHALL:no-error](https://hl7.org/fhir/extensions/CodeSystem-obligation.html#obligation-SHALL.58no-error) applies.
 
-This obligation is present in the underlying structure but due to a tooling limitation is not currently rendered in the profile view. See [Zulip discussion](https://chat.fhir.org/#narrow/stream/179252-IG-creation/topic/Obligation.20on.20ElementDefinition.2Etype) for more information.
+This obligation is present in the underlying structure but due to a tooling limitation is not currently rendered in the profile view. See [Zulip discussion](https://chat.fhir.org/#narrow/channel/179252-IG-creation/topic/Obligation.20Extension.20on.20ElementDefinition.2Etype.20not.20rendering) for more information.
 
 </div><!-- stu-note -->

--- a/input/intro-notes/StructureDefinition-au-core-condition-intro.md
+++ b/input/intro-notes/StructureDefinition-au-core-condition-intro.md
@@ -20,6 +20,6 @@ The following are supported usage scenarios for this profile:
 
 The additional obligation for `Condition.onsetDateTime` for [AU Core Responder](ActorDefinition-au-core-actor-responder.html) is [SHOULD:populate](https://hl7.org/fhir/extensions/CodeSystem-obligation.html#obligation-SHOULD.58populate). There is no additional obligation for [AU Core Requester](ActorDefinition-au-core-actor-requester.html), the obligation of [SHALL:no-error](https://hl7.org/fhir/extensions/CodeSystem-obligation.html#obligation-SHALL.58no-error) applies.
 
-This obligation is present in the underlying structure but due to a tooling limitation is not currently rendered in the profile view. See [Zulip discussion](https://chat.fhir.org/#narrow/stream/179252-IG-creation/topic/Obligation.20on.20ElementDefinition.2Etype) for more information.
+This obligation is present in the underlying structure but due to a tooling limitation is not currently rendered in the profile view. See [Zulip discussion](https://chat.fhir.org/#narrow/channel/179252-IG-creation/topic/Obligation.20Extension.20on.20ElementDefinition.2Etype.20not.20rendering) for more information.
 
 </div><!-- stu-note -->

--- a/input/intro-notes/StructureDefinition-au-core-immunization-intro.md
+++ b/input/intro-notes/StructureDefinition-au-core-immunization-intro.md
@@ -15,6 +15,6 @@ The following are supported usage scenarios for this profile:
 
 The additional obligation for `Immunization.occurrenceDateTime` for [AU Core Responder](ActorDefinition-au-core-actor-responder.html) is [SHOULD:populate](https://hl7.org/fhir/extensions/CodeSystem-obligation.html#obligation-SHOULD.58populate). There is no additional obligation for [AU Core Requester](ActorDefinition-au-core-actor-requester.html), the obligation of [SHALL:no-error](https://hl7.org/fhir/extensions/CodeSystem-obligation.html#obligation-SHALL.58no-error) applies.
 
-This obligation is present in the underlying structure but due to a tooling limitation is not currently rendered in the profile view. See [Zulip discussion](https://chat.fhir.org/#narrow/stream/179252-IG-creation/topic/Obligation.20on.20ElementDefinition.2Etype) for more information.
+This obligation is present in the underlying structure but due to a tooling limitation is not currently rendered in the profile view. See [Zulip discussion](https://chat.fhir.org/#narrow/channel/179252-IG-creation/topic/Obligation.20Extension.20on.20ElementDefinition.2Etype.20not.20rendering) for more information.
 
 </div><!-- stu-note -->

--- a/input/intro-notes/StructureDefinition-au-core-procedure-intro.md
+++ b/input/intro-notes/StructureDefinition-au-core-procedure-intro.md
@@ -21,6 +21,6 @@ The following are supported usage scenarios for this profile:
 
 The additional obligation for `Procedure.performedDateTime` for [AU Core Responder](ActorDefinition-au-core-actor-responder.html) is [SHOULD:populate](https://hl7.org/fhir/extensions/CodeSystem-obligation.html#obligation-SHOULD.58populate). There is no additional obligation for [AU Core Requester](ActorDefinition-au-core-actor-requester.html), the obligation of [SHALL:no-error](https://hl7.org/fhir/extensions/CodeSystem-obligation.html#obligation-SHALL.58no-error) applies.
 
-This obligation is present in the underlying structure but due to a tooling limitation is not currently rendered in the profile view. See [Zulip discussion](https://chat.fhir.org/#narrow/stream/179252-IG-creation/topic/Obligation.20on.20ElementDefinition.2Etype) for more information.
+This obligation is present in the underlying structure but due to a tooling limitation is not currently rendered in the profile view. See [Zulip discussion](https://chat.fhir.org/#narrow/channel/179252-IG-creation/topic/Obligation.20Extension.20on.20ElementDefinition.2Etype.20not.20rendering) for more information.
 
 </div><!-- stu-note -->


### PR DESCRIPTION
This PR fixes the broken Zulip links in STU Notes in profile intro files, see [QA issues: R2 updates](https://github.com/orgs/hl7au/projects/13/views/1?pane=issue&itemId=121872829). 

Changes in: 
- AU Core AllergyIntolerance intro
- AU Core Condition intro
- AU Core Immunization intro
- AU Core Procedure