### PR TITLE
FHIR-52607 Mandatory element consistently represented as min > 0 

### DIFF
--- a/input/pagecontent/general-requirements.md
+++ b/input/pagecontent/general-requirements.md
@@ -20,7 +20,7 @@ Implementers are advised to be familiar with the requirements of the FHIR standa
 #### AU Core Profiles and Extensions
 The [Profiles and Extensions](profiles-and-extensions.html) page lists the AU Core profiles and AU Core extensions defined for this implementation guide. An AU Core profile [StructureDefinition](http://hl7.org/fhir/R4/structuredefinition.html) defines the minimum elements, extensions, vocabularies and value sets that **SHALL** be present and constrains the way elements are used when conforming to the profile.
 
-AU Core profile elements include mandatory and *Must Support* requirements. [Mandatory Elements](#mandatory-elements) are required and have a minimum cardinality of 1 (min=1). [Must Support](#must-support-and-obligation) elements have defined conformance obligations in AU Core based on actor roles.
+AU Core profile elements include mandatory and *Must Support* requirements. [Mandatory Elements](#mandatory-elements) are required and have a minimum cardinality > 0. [Must Support](#must-support-and-obligation) elements have defined conformance obligations in AU Core based on actor roles.
 
 Systems may implement AU Core as: 
 - [Profile Only Support](#profile-only-support) for a system declaring conformance to one or more AU Core profiles


### PR DESCRIPTION
[FHIR-52607](https://jira.hl7.org/browse/FHIR-52607)

Updated wording for mandatory element from "Mandatory elements are required and have a minimum cardinality of 1 (min=1)." to "Mandatory elements are required and have a minimum cardinality > 0." for consistency.