### PR TITLE
Clarify intro sentence for Choice of Identifiers table (FHIR-52525) 

### DIFF
--- a/input/pagecontent/general-requirements.md
+++ b/input/pagecontent/general-requirements.md
@@ -262,7 +262,7 @@ A profile may support one or more than one identifier type and will include the 
 - AU Core Responders **SHALL** correctly populate the element with identifiers from at least one supported identifier type where the identifier is known.
 - AU Core Requesters **SHALL** accept resources without error if the element is present and containing any identifier type allowed by the element definition.
 
-The table below provides a list of AU Core profile elements that allow multiple identifier types.
+The table below provides a list of AU Core profile elements with one or more supported identifier types.
 
 AU Core Profile |Must Support Element|Supported Identifiers
 ---|---|---


### PR DESCRIPTION
[FHIR-52525] (https://jira.hl7.org/browse/FHIR-52525)

Changed intro sentence of identifier table from: "The table below provides a list of AU Core profile elements that allow multiple identifier types." to: "The table below provides a list of AU Core profile elements with one or more supported identifier types." for clarity.

File changed: input/pagecontent/general-requirements.md