### PR TITLE
TC: remove erroneous square brackets from Declaring Conformance example (AU PS FHIR-56143)

### DIFF
--- a/input/pagecontent/declaring-conformance.md
+++ b/input/pagecontent/declaring-conformance.md
@@ -24,9 +24,7 @@ Example: CapabilityStatement resource for a server supporting the AU Core Patien
               ...
               {
                 "type": "Patient",
-                "profile": [
-                  "http://hl7.org/fhir/us/core/StructureDefinition/au-core-patient"
-                ],
+                "profile": "http://hl7.org/fhir/us/core/StructureDefinition/au-core-patient",
                 ...
               }
             ]

--- a/input/pagecontent/declaring-conformance.md
+++ b/input/pagecontent/declaring-conformance.md
@@ -24,7 +24,7 @@ Example: CapabilityStatement resource for a server supporting the AU Core Patien
               ...
               {
                 "type": "Patient",
-                "profile": "http://hl7.org/fhir/us/core/StructureDefinition/au-core-patient",
+                "profile": "http://hl7.org.au/fhir/core/StructureDefinition/au-core-patient",
                 ...
               }
             ]


### PR DESCRIPTION
Fix for [FHIR-56143](https://jira.hl7.org/browse/FHIR-56143)
* Remove erroneous square bracket in first example on Declaring Conformance