### PR TITLE
Align ABN identifier examples with AU Base and update change log (FHIR-56103)

### DIFF
--- a/input/examples/organization-bobrester-medical-center.xml
+++ b/input/examples/organization-bobrester-medical-center.xml
@@ -7,8 +7,8 @@
     <identifier>
         <type>
             <coding>
-                <system value="http://terminology.hl7.org/CodeSystem/v2-0203"/>
-                <code value="XX"/>
+                <system value="http://terminology.hl7.org.au/CodeSystem/v2-0203"/>
+                <code value="ABN"/>
             </coding>
             <text value="ABN"/>
         </type>

--- a/input/examples/organization-mitchells-hill-audiology.xml
+++ b/input/examples/organization-mitchells-hill-audiology.xml
@@ -19,8 +19,8 @@
   <identifier>
     <type>
       <coding>
-        <system value="http://terminology.hl7.org/CodeSystem/v2-0203"/>
-        <code value="XX"/>
+        <system value="http://terminology.hl7.org.au/CodeSystem/v2-0203"/>
+        <code value="ABN"/>
       </coding>
       <text value="ABN"/>
     </type>

--- a/input/pagecontent/changes.md
+++ b/input/pagecontent/changes.md
@@ -10,7 +10,7 @@ This change log documents the significant updates and resolutions implemented fr
   - added AU HAE as an allowed type for Organization.identifier [AU Base: FHIR-54928](https://jira.hl7.org/browse/FHIR-54928)
   - added AU HSP-O as an allowed type for Organization.identifier [AU Base: FHIR-54923](https://jira.hl7.org/browse/FHIR-54923)
   - removed invariant au-core-org-01 limiting a National Organization Identifier to an HPI-O or PAI-O [AU Core: FHIR-55738](https://jira.hl7.org/browse/FHIR-55738)
-  - changed Organization.identifier:abn.type to require code ABN from the IdentifierType AU code system (http://terminology.hl7.org.au/CodeSystem/v2-0203) [AU Base: FHIR-FHIR-56103](https://jira.hl7.org/browse/FHIR-56103)
+  - changed Organization.identifier:abn.type to require code ABN from the IdentifierType AU code system [AU Base: FHIR-56103](https://jira.hl7.org/browse/FHIR-56103)
 
 ### Release 2.0.0
 - Publication date: 2026-01-28

--- a/input/pagecontent/changes.md
+++ b/input/pagecontent/changes.md
@@ -10,6 +10,7 @@ This change log documents the significant updates and resolutions implemented fr
   - added AU HAE as an allowed type for Organization.identifier [AU Base: FHIR-54928](https://jira.hl7.org/browse/FHIR-54928)
   - added AU HSP-O as an allowed type for Organization.identifier [AU Base: FHIR-54923](https://jira.hl7.org/browse/FHIR-54923)
   - removed invariant au-core-org-01 limiting a National Organization Identifier to an HPI-O or PAI-O [AU Core: FHIR-55738](https://jira.hl7.org/browse/FHIR-55738)
+  - changed Organization.identifier:abn.type to require code ABN from the IdentifierType AU code system (http://terminology.hl7.org.au/CodeSystem/v2-0203) [AU Base: FHIR-FHIR-56103](https://jira.hl7.org/browse/FHIR-56103)
 
 ### Release 2.0.0
 - Publication date: 2026-01-28


### PR DESCRIPTION
This PR aligns the AU Core Organization examples that use the ABN identifier type with the latest AU Base changes  https://jira.hl7.org/browse/FHIR-56103. Identifier.type now uses code ABN from the Australian Identifier Type code system (http://terminology.hl7.org.au/CodeSystem/v2-0203) instead of the previous extensible binding approach. 

This also removes errors from the qa.html: 
> The pattern [system http://terminology.hl7.org.au/CodeSystem/v2-0203, code ABN, and display 'null'] defined in the profile http://hl7.org.au/fhir/StructureDefinition/au-australianbusinessnumber|6.0.1-ci-build not found.

Changes:
- updated examples to use the new ABN pattern
- change log entry for AU Base: [FHIR-56103](https://jira.hl7.org/browse/FHIR-56103)