### PR TITLE
 Reference RelatedPerson-patient instead of au-core-clinical-patient for the RelatedPerson patient search parameter (FHIR-57758)

### DIFF
--- a/input/pagecontent/changes.md
+++ b/input/pagecontent/changes.md
@@ -19,9 +19,9 @@ This change log documents the significant updates and resolutions implemented fr
   - removed invariant au-core-org-01 limiting a National Organization Identifier to an HPI-O or PAI-O [AU Core: FHIR-55738](https://jira.hl7.org/browse/FHIR-55738)
   - changed Organization.identifier:abn.type to require code ABN from the IdentifierType AU code system [AU Base: FHIR-56103](https://jira.hl7.org/browse/FHIR-56103)
 - [AU Core Requester CapabilityStatement](CapabilityStatement-au-core-requester.html) 
-  - applied technical correction to reference the RelatedPerson-patient search parameter instead of the AU Core clinical-patient search parameter for RelatedPerson [AU Core: FHIR-57758](https://jira.hl7.org/browse/FHIR-57758) 
+  - corrected url for RelatedPerson-patient search parameter [AU Core: FHIR-57758](https://jira.hl7.org/browse/FHIR-57758) 
 - [AU Core Responder CapabilityStatement](CapabilityStatement-au-core-responder.html)
-  - applied technical correction to reference the RelatedPerson-patient search parameter instead of the AU Core clinical-patient search parameter for RelatedPerson [AU Core: FHIR-57758](https://jira.hl7.org/browse/FHIR-57758)  
+  - corrected url for RelatedPerson-patient search parameter [AU Core: FHIR-57758](https://jira.hl7.org/browse/FHIR-57758)  
 
 ### Release 2.0.0
 - Publication date: 2026-01-28

--- a/input/pagecontent/changes.md
+++ b/input/pagecontent/changes.md
@@ -18,6 +18,10 @@ This change log documents the significant updates and resolutions implemented fr
   - added AU HSP-O as an allowed type for Organization.identifier [AU Base: FHIR-54923](https://jira.hl7.org/browse/FHIR-54923)
   - removed invariant au-core-org-01 limiting a National Organization Identifier to an HPI-O or PAI-O [AU Core: FHIR-55738](https://jira.hl7.org/browse/FHIR-55738)
   - changed Organization.identifier:abn.type to require code ABN from the IdentifierType AU code system [AU Base: FHIR-56103](https://jira.hl7.org/browse/FHIR-56103)
+- [AU Core Requester CapabilityStatement](CapabilityStatement-au-core-requester.html) 
+  - applied technical correction to reference the RelatedPerson-patient search parameter instead of the AU Core clinical-patient search parameter for RelatedPerson [AU Core: FHIR-57758](https://jira.hl7.org/browse/FHIR-57758) 
+- [AU Core Responder CapabilityStatement](CapabilityStatement-au-core-responder.html)
+  - applied technical correction to reference the RelatedPerson-patient search parameter instead of the AU Core clinical-patient search parameter for RelatedPerson [AU Core: FHIR-57758](https://jira.hl7.org/browse/FHIR-57758)  
 
 ### Release 2.0.0
 - Publication date: 2026-01-28

--- a/input/resources/au-core-requester.xml
+++ b/input/resources/au-core-requester.xml
@@ -1517,7 +1517,7 @@
 <valueCode value="SHALL"/>
 </extension>
 <name value="patient"/>
-<definition value="http://hl7.org.au/fhir/core/SearchParameter/au-core-clinical-patient"/>
+<definition value="http://hl7.org/fhir/SearchParameter/RelatedPerson-patient"/>
 <type value="reference"/>
 <documentation value="The requester **SHALL** provide at least an id value and **MAY** provide both the Type and id values.&#xa;&#xa;The responder **SHALL** support both.&#xa;&#xa;The requester **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile.&#xa;&#xa;The responder **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile."/>
 </searchParam>

--- a/input/resources/au-core-responder.xml
+++ b/input/resources/au-core-responder.xml
@@ -1507,7 +1507,7 @@
 <valueCode value="SHALL"/>
 </extension>
 <name value="patient"/>
-<definition value="http://hl7.org.au/fhir/core/SearchParameter/au-core-clinical-patient"/>
+<definition value="http://hl7.org/fhir/SearchParameter/RelatedPerson-patient"/>
 <type value="reference"/>
 <documentation value="The requester **SHALL** provide at least an id value and **MAY** provide both the Type and id values.&#xa;&#xa;The responder **SHALL** support both.&#xa;&#xa;The requester **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile.&#xa;&#xa;The responder **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile."/>
 </searchParam>


### PR DESCRIPTION
Fix for https://jira.hl7.org/browse/FHIR-57758. 

Update both the AU Core Requester and Responder CapabilityStatements to reference RelatedPerson-patient instead of au-core-clinical-patient for the RelatedPerson patient search parameter. 

Changes in:
- AU Core Requester CapabilityStatements 
- AU Core Responder CapabilityStatements 
- change log