### PR TITLE
Adopt centralized pipeline (thin caller); keep legacy pipelines alongside

### DIFF
--- a/.github/workflows/build-review-publish.yml
+++ b/.github/workflows/build-review-publish.yml
@@ -1,0 +1,50 @@
+name: AU Core — build / preview / gated publish
+
+# Thin caller for the CENTRALIZED reusable pipeline in hl7au/publications. The full build → preview →
+# publish logic lives once at hl7au/publications/.github/workflows/build-review-publish.yml; this stub
+# just forwards au-fhir-core's events to it. subtree="core" → au-core owns only the /fhir/core
+# subtree (au-base owns the /fhir root); the reusable workflow scopes the prod sync accordingly and
+# uploads only the shared root files au-core read-modify-writes.
+#
+# RELEASE FLOW: push a release-<version> tag on the release commit (publication-request.json must name
+# the same version). A working status (draft/ballot/preview) publishes to prod automatically as a
+# versioned snapshot; a milestone status (release/trial-use/normative — becomes 'current') waits for
+# one approval on THIS repo's `production` environment (deployment rules = master + v* + release-*).
+#
+# The legacy workflows (snapshot_build.yml / milestone_build.yml) deliberately stay tag-triggered
+# alongside: they stop at the staging bucket / EC2 webroot with a manual prod push, so either release
+# method can be used without conflict.
+
+on:
+  push:
+    branches: [master]
+    tags: ['v*', 'release-*']   # release-<version> is the established AU tagging convention
+  pull_request:
+    branches: [master]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Tag/branch of au-fhir-core to build"
+        default: master
+      publish_milestone:
+        description: "Promote the MILESTONE build to prod S3 (becomes 'current'; gated)"
+        type: boolean
+        default: false
+      publish_working:
+        description: "Publish the WORKING build to prod S3 (versioned snapshot, NOT current)"
+        type: boolean
+        default: false
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  pipeline:
+    uses: hl7au/publications/.github/workflows/build-review-publish.yml@master
+    with:
+      subtree: "core"                                      # au-core owns only the /fhir/core subtree
+      ref: ${{ inputs.ref || '' }}
+      publish_milestone: ${{ inputs.publish_milestone || false }}
+      publish_working: ${{ inputs.publish_working || false }}
+    secrets: inherit

--- a/.github/workflows/milestone_build.yml
+++ b/.github/workflows/milestone_build.yml
@@ -1,4 +1,10 @@
-name: Milestone - Au base IG Profiles publish->go-publish
+name: (LEGACY) Milestone - Au Core IG Profiles publish->go-publish
+
+# LEGACY pipeline, deliberately kept TAG-TRIGGERED alongside the centralized build-review-publish.yml
+# so either release method can be used: this one renders into the self-hosted EC2 /webroot and pushing
+# to prod stays a manual step, so the two coexist without conflict. The centralized caller publishes
+# per publication-request status (working = automatic, milestone = gated by the production
+# environment).
 
 on:
   push:

--- a/.github/workflows/snapshot_build.yml
+++ b/.github/workflows/snapshot_build.yml
@@ -1,4 +1,10 @@
-name: Au Core IG Profiles publish->go-publish
+name: (LEGACY) Au Core IG Profiles publish->go-publish - snapshots
+
+# LEGACY pipeline, deliberately kept TAG-TRIGGERED alongside the centralized build-review-publish.yml
+# so either release method can be used: this one renders and uploads to the s3://action-runner-working
+# staging bucket and pushing to prod stays a manual step, so the two coexist without conflict. The
+# centralized caller publishes per publication-request status (working = automatic, milestone = gated
+# by the production environment).
 
 on:
   push:


### PR DESCRIPTION
Brings au-fhir-core to the same standard as au-fhir-base (and au-fhir-ps PR #145): a thin caller stub forwarding to the centralized reusable pipeline in hl7au/publications, with `subtree: core` scoping the prod sync to `/fhir/core` + the shared root files.

## Release flow

Push `release-<version>` on the release commit (au-core's existing tag convention — `release-2.0.0-draft`, `release-2.0.0`, …):

| `publication-request.json` status | path | gate |
|---|---|---|
| draft / ballot / preview (**working**) | versioned snapshot, `current` untouched, additive only | **automatic** — the tag is the approval |
| release / trial-use / normative (**milestone**) | full promote, becomes `current` | one `production`-environment approval |

Both paths refuse loudly if the tag doesn't match the publication-request version, and end with CloudFront invalidation + post-publish verify. The `production` environment (reviewers: brettesler-ext, dt-r, KyleOps; deployment rules master + `v*` + `release-*`) has been set up.

## Legacy pipelines kept alongside

`snapshot_build.yml` and `milestone_build.yml` stay tag-triggered (now labelled LEGACY): they stop at the `action-runner-working` staging bucket / EC2 webroot with a manual prod push, so either release method can be used without conflict. A release tag runs both; the legacy ones don't touch prod.

## ⚠️ Before today's publication

`publication-request.json` on master is stale (`0.5.0-ci-build`) — the release commit must set the real version/path/status (e.g. `2.1.0-draft`, `http://hl7.org.au/fhir/core/2.1.0-draft`, `status: draft`) or the tag guard will refuse to publish (by design).