### PR TITLE
Release-triggered preprod; drop prod-publish inputs from the caller stub

### DIFF
--- a/.github/workflows/build-review-publish.yml
+++ b/.github/workflows/build-review-publish.yml
@@ -1,41 +1,31 @@
-name: AU Core — build / preview / gated publish
+name: AU Core — build / preview / release to preprod
 
 # Thin caller for the CENTRALIZED reusable pipeline in hl7au/publications. The full build → preview →
-# publish logic lives once at hl7au/publications/.github/workflows/build-review-publish.yml; this stub
-# just forwards au-fhir-core's events to it. subtree="core" → au-core owns only the /fhir/core
-# subtree (au-base owns the /fhir root); the reusable workflow scopes the prod sync accordingly and
-# uploads only the shared root files au-core read-modify-writes.
+# preprod-deploy logic lives once at hl7au/publications/.github/workflows/build-review-publish.yml;
+# this stub just forwards au-fhir-core's events to it. subtree="core" → au-core owns only the
+# /fhir/core subtree (au-base owns the /fhir root); the reusable workflow scopes the preprod sync
+# accordingly and uploads only the shared root files au-core read-modify-writes.
 #
-# RELEASE FLOW: push a release-<version> tag on the release commit (publication-request.json must name
-# the same version). A working status (draft/ballot/preview) publishes to prod automatically as a
-# versioned snapshot; a milestone status (release/trial-use/normative — becomes 'current') waits for
-# one approval on THIS repo's `production` environment (deployment rules = master + v* + release-*).
-#
-# The legacy workflows (snapshot_build.yml / milestone_build.yml) deliberately stay tag-triggered
-# alongside: they stop at the staging bucket / EC2 webroot with a manual prod push, so either release
-# method can be used without conflict.
+# RELEASE FLOW: publication/release branches are never merged to master (master = CI build). Cut a
+# GitHub RELEASE targeting the release branch → this builds and deploys to PREPROD (staging). PROD is
+# NOT published from here: promotion is a manual, HL7 AU-only step in the publications repo
+# (Actions → "Promote preprod → prod"), which copies the approved preprod content to prod. See the
+# reusable workflow + publications docs/publication-process.md for the full design.
 
 on:
   push:
-    branches: [master]
-    tags: ['v*', 'release-*']   # release-<version> is the established AU tagging convention
+    branches: [master]          # CI validation build only (no deploy)
   pull_request:
     branches: [master]
+  release:
+    types: [published]          # a GitHub release → build + deploy to preprod (staging)
   workflow_dispatch:
     inputs:
       ref:
         description: "Tag/branch of au-fhir-core to build"
         default: master
-      publish_milestone:
-        description: "Promote the MILESTONE build to prod S3 (becomes 'current'; gated)"
-        type: boolean
-        default: false
-      publish_working:
-        description: "Publish the WORKING build to prod S3 (versioned snapshot, NOT current)"
-        type: boolean
-        default: false
       deploy_preprod:
-        description: "Deploy this build to preprod (staging behind the real CloudFront setup)"
+        description: "Deploy this build to preprod (on-demand branch staging behind the real CloudFront setup)"
         type: boolean
         default: false
 
@@ -49,7 +39,5 @@ jobs:
     with:
       subtree: "core"                                      # au-core owns only the /fhir/core subtree
       ref: ${{ inputs.ref || '' }}
-      publish_milestone: ${{ inputs.publish_milestone || false }}
-      publish_working: ${{ inputs.publish_working || false }}
       deploy_preprod: ${{ inputs.deploy_preprod || false }}
     secrets: inherit

--- a/.github/workflows/build-review-publish.yml
+++ b/.github/workflows/build-review-publish.yml
@@ -40,4 +40,5 @@ jobs:
       subtree: "core"                                      # au-core owns only the /fhir/core subtree
       ref: ${{ inputs.ref || '' }}
       deploy_preprod: ${{ inputs.deploy_preprod || false }}
+      qa_max_errors: 4                                     # QA gate: current baseline is 4 errors — ratchet down as they're fixed
     secrets: inherit

--- a/.github/workflows/build-review-publish.yml
+++ b/.github/workflows/build-review-publish.yml
@@ -32,6 +32,7 @@ on:
 permissions:
   id-token: write
   contents: read
+  pull-requests: write   # let the reusable QA gate upsert its summary comment on PRs
 
 jobs:
   pipeline:
@@ -40,5 +41,4 @@ jobs:
       subtree: "core"                                      # au-core owns only the /fhir/core subtree
       ref: ${{ inputs.ref || '' }}
       deploy_preprod: ${{ inputs.deploy_preprod || false }}
-      qa_max_errors: 4                                     # QA gate: current baseline is 4 errors — ratchet down as they're fixed
     secrets: inherit


### PR DESCRIPTION
Update the caller stub for the release-triggered / manual-promote model (paired with hl7au/publications#12).

- **Deploy to preprod on a GitHub release** (`published`) instead of on a merge to master.
- **Remove `publish_milestone` / `publish_working` inputs.** Prod is promoted manually from the publications repo (`Actions → "Promote preprod → prod"`), HL7 AU only.
- **Drop the `tags:` push trigger** so a release tag does not also run the pipeline as a bare tag push.
- **QA gate** baseline `qa_max_errors: 4` (au-core's current error count) — the build fails on a new (5th) error; ratchet down as they are fixed.

> Depends on hl7au/publications#12 (reusable workflow). Merge that first.
> Note: legacy `pipeline-build.yml` (self-hosted, `push: tags: "**"`) is left in place for now.