### PR TITLE
Update AU Core MedicationDispense examples 

### DIFF
--- a/input/examples/medication-lipex.xml
+++ b/input/examples/medication-lipex.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Medication xmlns="http://hl7.org/fhir">
+  <id value="lipex"/>
+  <meta>
+    <profile value="http://hl7.org.au/fhir/core/StructureDefinition/au-core-medication"/>
+  </meta>
+  <code>
+    <coding>
+      <system value="http://snomed.info/sct"/>
+      <code value="6193011000036"/>
+      <display value="Lipex 40 mg tablet"/>
+    </coding>
+  </code>
+</Medication>

--- a/input/examples/medicationdispense-lipex.xml
+++ b/input/examples/medicationdispense-lipex.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <MedicationDispense xmlns="http://hl7.org/fhir">
-    <id value="simvastatin"/>
+    <id value="lipex"/>
     <meta>
         <profile value="http://hl7.org.au/fhir/core/StructureDefinition/au-core-medicationdispense"/>
     </meta>
     <status value="completed"/>
     <medicationReference>
-        <reference value="Medication/simvastatin"/>
+        <reference value="Medication/lipex"/>
     </medicationReference>
     <subject>
         <reference value="Patient/wang-li"/>

--- a/input/examples/medicationdispense-lipex.xml
+++ b/input/examples/medicationdispense-lipex.xml
@@ -13,7 +13,7 @@
     </subject>
     <performer>
         <actor>
-            <display value="Main Street Pharmacy"/>
+            <reference value="Organization/appin-pharmacy"/>
         </actor>
     </performer>
     <authorizingPrescription>

--- a/input/examples/medicationdispense-panadeine-forte.xml
+++ b/input/examples/medicationdispense-panadeine-forte.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <MedicationDispense xmlns="http://hl7.org/fhir">
-    <id value="paracetamol-codeine"/>
+    <id value="panadeine-forte"/>
     <meta>
         <profile value="http://hl7.org.au/fhir/core/StructureDefinition/au-core-medicationdispense"/>
     </meta>
@@ -8,8 +8,8 @@
     <medicationCodeableConcept>
         <coding>
             <system value="http://snomed.info/sct"/>
-            <code value="79115011000036100"/>
-            <display value="Paracetamol 500 mg + codeine phosphate hemihydrate 30 mg tablet"/>
+            <code value="835831000168109"/>
+            <display value="Panadeine Forte tablet"/>
         </coding>
     </medicationCodeableConcept>
     <subject>

--- a/input/examples/medicationdispense-paracetamol-codeine.xml
+++ b/input/examples/medicationdispense-paracetamol-codeine.xml
@@ -17,7 +17,7 @@
     </subject>
     <performer>
         <actor>
-            <display value="Main Street Pharmacy"/>
+           <reference value="Organization/appin-pharmacy"/>
         </actor>
     </performer>
     <authorizingPrescription>

--- a/input/examples/medicationdispense-paracetamol-codeine.xml
+++ b/input/examples/medicationdispense-paracetamol-codeine.xml
@@ -30,7 +30,9 @@
         <code value="TAB"/>
     </quantity>
     <whenPrepared value="2018-07-15"/>
-    <note value="Consumer advised not to exceed 8 tablets in 24 hours."/>
+    <note>
+        <text value="Consumer advised not to exceed 8 tablets in 24 hours."/>
+    </note>
     <dosageInstruction>
         <text value="1-2 tablets every 4-6 hours as needed for pain"/>
         <timing>

--- a/input/examples/medicationdispense-paracetamol-codeine.xml
+++ b/input/examples/medicationdispense-paracetamol-codeine.xml
@@ -30,6 +30,7 @@
         <code value="TAB"/>
     </quantity>
     <whenPrepared value="2018-07-15"/>
+    <note value="Consumer advised not to exceed 8 tablets in 24 hours."/>
     <dosageInstruction>
         <text value="1-2 tablets every 4-6 hours as needed for pain"/>
         <timing>

--- a/input/examples/medicationdispense-reaptan.xml
+++ b/input/examples/medicationdispense-reaptan.xml
@@ -25,7 +25,7 @@
     </subject>
     <performer>
         <actor>
-            <display value="Main Street Pharmacy"/>
+            <reference value="Organization/appin-pharmacy"/>
         </actor>
     </performer>
     <authorizingPrescription>

--- a/input/examples/organization-appin-pharmacy.xml
+++ b/input/examples/organization-appin-pharmacy.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Organization xmlns="http://hl7.org/fhir">
+  <id value="appin-pharmacy"/>
+  <meta>
+    <profile value="http://hl7.org.au/fhir/core/StructureDefinition/au-core-organization"/>
+  </meta>
+  <identifier>
+    <type>
+      <coding>
+        <system value="http://terminology.hl7.org.au/CodeSystem/v2-0203"/>
+        <code value="NOI"/>
+        <display value="National Organisation Identifier"/>
+      </coding>
+      <text value="HPI-O"/>
+    </type>
+    <system value="http://ns.electronichealth.net.au/id/hi/hpio/1.0"/>
+    <value value="8003629900040417"/>
+  </identifier>
+  <identifier>
+    <type>
+      <coding>
+        <system value="http://terminology.hl7.org.au/CodeSystem/v2-0203"/>
+        <code value="ABN"/>
+      </coding>
+      <text value="ABN"/>
+    </type>
+    <system value="http://hl7.org.au/id/abn"/>
+    <value value="81124140480"/>
+  </identifier>
+  <type>
+    <coding>
+      <system value="http://www.abs.gov.au/ausstats/abs@.nsf/mf/1292.0"/>
+      <code value="4271"/>
+      <display value="Pharmaceutical, Cosmetic and Toiletry Goods Retailing"/>
+    </coding>
+    <coding>
+      <system value="http://snomed.info/sct"/>
+      <code value="310080006"/>
+      <display value="Pharmacy service"/>
+    </coding>
+    <text value="Community Pharmacy"/>
+  </type>
+  <name value="Appin Pharmacy"/>
+  <telecom>
+    <system value="phone"/>
+    <value value="0255500340"/>
+    <use value="work"/>
+  </telecom>
+  <telecom>
+    <system value="email"/>
+    <value value="reception@appinpharmacy.example.com.au"/>
+    <use value="work"/>
+  </telecom>
+  <address>
+    <line value="124 Hendrix Ave"/>
+    <city value="Appin"/>
+    <state value="NSW"/>
+    <postalCode value="2560"/>
+  </address>
+</Organization>

--- a/input/ig.xml
+++ b/input/ig.xml
@@ -469,6 +469,14 @@
 			<description value="Shows an example of Simvastatin 40 mg oral tablet for the *AU Core Medication* profile. Includes a SNOMED CT code for the medication."/>
 			<exampleCanonical value="http://hl7.org.au/fhir/core/StructureDefinition/au-core-medication"/>
 		</resource>
+				<resource>
+			<reference>
+				<reference value="Medication/lipex"/>
+			</reference>
+			<name value="Medication - Lipex 40 mg tablet"/>
+			<description value="Shows an example of Lipex 40 mg tablet for the *AU Core Medication* profile. Includes a SNOMED CT code for the medication."/>
+			<exampleCanonical value="http://hl7.org.au/fhir/core/StructureDefinition/au-core-medication"/>
+		</resource>
 		<!--MEDICATIONREQUEST EXAMPLES-->
 		<resource>
 			<reference>
@@ -513,10 +521,10 @@
 		</resource>
 		<resource>
 			<reference>
-				<reference value="MedicationDispense/simvastatin"/>
+				<reference value="MedicationDispense/lipex"/>
 			</reference>
-			<name value="MedicationDispense - completed supply, Simvastatin"/>
-			<description value="Shows an example of the completed supply (dispense) of Simvastatin 40 mg oral tablet for the *AU Core MedicationDispense* profile, demonstrating representation of medication as a reference to a Medication resource and a reference to the authorising prescription. Patient: Mr. Li Wang."/>
+			<name value="MedicationDispense - completed supply, Lipex"/>
+			<description value="Shows an example of the completed supply (dispense) of Lipex 40 mg tablet for the *AU Core MedicationDispense* profile, demonstrating representation of medication as a reference to a Medication resource and a reference to the authorising prescription. Patient: Mr. Li Wang."/>
 			<exampleCanonical value="http://hl7.org.au/fhir/core/StructureDefinition/au-core-medicationdispense"/>
 		</resource>
 		<!--MEDICATIONSTATEMENT EXAMPLES-->

--- a/input/ig.xml
+++ b/input/ig.xml
@@ -730,6 +730,14 @@
 			<description value="Shows an example of an organisation, Pullabooka Pathology, for the *AU Core Organization* profile, with HPI-O identifier, type specified as a pathology service, with contact details and partial address."/>
 			<exampleCanonical value="http://hl7.org.au/fhir/core/StructureDefinition/au-core-organization"/>
 		</resource>
+		<resource>
+			<reference>
+				<reference value="Organization/appin-pharmacy"/>
+			</reference>
+			<name value="Organization - Appin Pharmacy"/>
+			<description value="Shows an example of an organisation, Appin Pharmacy, for the *AU Core Organization* profile, with HPI-O and ABN identifiers, type specified as a community pharmacy, with contact details and partial address."/>
+			<exampleCanonical value="http://hl7.org.au/fhir/core/StructureDefinition/au-core-organization"/>
+		</resource>
 		<!--PATIENT EXAMPLES-->
 		<resource>
 			<reference>

--- a/input/ig.xml
+++ b/input/ig.xml
@@ -505,10 +505,10 @@
 		<!--MEDICATIONDISPENSE EXAMPLES-->
 		<resource>
 			<reference>
-				<reference value="MedicationDispense/paracetamol-codeine"/>
+				<reference value="MedicationDispense/panadeine-forte"/>
 			</reference>
-			<name value="MedicationDispense - completed supply, paracetamol 500 mg + codeine phosphate hemihydrate 30 mg"/>
-			<description value="Shows an example of the completed supply (dispense) of paracetamol 500 mg + codeine phosphate hemihydrate 30 mg tablet for pain management for the *AU Core MedicationDispense* profile, demonstrating representation of medication as a code. Patient: Mrs. Anne Bennelong."/>
+			<name value="MedicationDispense - completed supply, Panadeine Forte tablet"/>
+			<description value="Shows an example of the completed supply (dispense) of Panadeine Forte tablet for pain management for the *AU Core MedicationDispense* profile, demonstrating representation of medication as a code, with a reference to the authorising prescription, dosage instructions, and a dispensing note. Patient: Mrs. Anne Bennelong."/>
 			<exampleCanonical value="http://hl7.org.au/fhir/core/StructureDefinition/au-core-medicationdispense"/>
 		</resource>
 		<resource>
@@ -516,7 +516,7 @@
 				<reference value="MedicationDispense/reaptan"/>
 			</reference>
 			<name value="MedicationDispense - completed supply, Reaptan"/>
-			<description value="Shows an example of the completed supply (dispense) of Reaptan 10 mg/10 mg for the *AU Core MedicationDispense* profile, demonstrating representation of medication as a reference to a contained Medication resource. Patient: Mr. Li Wang."/>
+			<description value="Shows an example of the completed supply (dispense) of Reaptan 10 mg/10 mg for the *AU Core MedicationDispense* profile, demonstrating representation of medication as a reference to a contained Medication resource, with a reference to the authorising prescription and dosage instructions. Patient: Mr. Li Wang."/>
 			<exampleCanonical value="http://hl7.org.au/fhir/core/StructureDefinition/au-core-medicationdispense"/>
 		</resource>
 		<resource>


### PR DESCRIPTION
Update the AU Core MedicationDispense examples, related to backlog item https://github.com/orgs/hl7au/projects/28/views/1?pane=issue&itemId=211199202.

Changes:
- Update MedicationDispense/paracetamol-codeine to reference the trade packaged product "835831000168109" instead of medicinal product "79115011000036100"
- Update MedicationDispense/simvastatin to reference the trade packaged product "6193011000036" instead of medicinal product "235250110000361096".
- Rename example ids to better align with the example content 
- Add corresponding Medication/lipex example for the updated trade packaged product "6193011000036" 
- Add a pharmacy Organization example and reference it from the MedicationDispense examples.
- Add MedicationDispense.note to ensure full coverage of all MS elements.

_**Note**: QA Report has a terminology validation error  related to trade packaged product "6193011000036". Will follow up with @mjosborne1, who recommended the code._ 
 