### PR TITLE
Standardise missing and no known example IDs

### DIFF
--- a/input/examples/condition-masked.xml
+++ b/input/examples/condition-masked.xml
@@ -1,5 +1,5 @@
 <Condition xmlns="http://hl7.org/fhir">
-  <id value="condition-masked"/>
+  <id value="masked"/>
   <meta>
     <profile value="http://hl7.org.au/fhir/core/StructureDefinition/au-core-condition"/>
   </meta>

--- a/input/examples/condition-noneknown.xml
+++ b/input/examples/condition-noneknown.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Condition xmlns="http://hl7.org/fhir">
-    <id value="noknown"/>
+    <id value="noneknown"/>
     <meta>
         <profile value="http://hl7.org.au/fhir/core/StructureDefinition/au-core-condition"/>
     </meta>

--- a/input/examples/observation-masked.xml
+++ b/input/examples/observation-masked.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Observation xmlns="http://hl7.org/fhir">
-  <id value="observation-masked"/>
+  <id value="masked"/>
   <meta>
     <profile value="http://hl7.org.au/fhir/core/StructureDefinition/au-core-diagnosticresult"/>
   </meta>

--- a/input/ig.xml
+++ b/input/ig.xml
@@ -312,7 +312,7 @@
 		</resource>
 		<resource>
 			<reference>
-				<reference value="Condition/noknown"/>
+				<reference value="Condition/noneknown"/>
 			</reference>
 			<name value="Condition - No known condition"/>
 			<description value="Shows an example of no known conditions for the *AU Core Condition* profile. Patient: Deangelo HOWE."/>

--- a/input/ig.xml
+++ b/input/ig.xml
@@ -304,7 +304,7 @@
 		</resource>
 		<resource>
 			<reference>
-				<reference value="Condition/condition-masked"/>
+				<reference value="Condition/masked"/>
 			</reference>
 			<name value="Condition - Data suppressed for category and code"/>
 			<description value="Shows an example of a condition with suppressed data (category and code) where the data requester has access rights to know that data is suppressed for the *AU Core Condition* profile. Patient: Anne Bennelong."/>
@@ -707,7 +707,7 @@
 		</resource>
 		<resource>
 			<reference>
-				<reference value="Observation/observation-masked"/>
+				<reference value="Observation/masked"/>
 			</reference>
 			<name value="Observation - Data suppressed for category, code, effective[x] and value[x]"/>
 			<description value="Shows an example of an observation with suppressed data (category, code, effectivePeriod, and valueQuantity) where the data requester has access rights to know that data is suppressed for the  *AU Core Diagnostic Result Observation* profile. Patient: Ronny Lawrence Irvine."/>

--- a/input/pagecontent/examples.md
+++ b/input/pagecontent/examples.md
@@ -20,8 +20,8 @@ In addition to the examples defined in this implementation, synthetic (realistic
 * [MedicationRequest - prescription, paracetamol 500 mg + codeine phosphate hemihydrate 30 mg (missing data for status and requester)](MedicationRequest-paracetamol-codeine.html) 
 
 ### Suppressed Data
-* [Condition - Data suppressed for category and code](Condition-condition-masked.html)
-* [Observation - Data suppressed for category, code and effectiveDate](Observation-observation-masked.html)
+* [Condition - Data suppressed for category and code](Condition-masked.html)
+* [Observation - Data suppressed for category, code and effectiveDate](Observation-masked.html)
 
 
 


### PR DESCRIPTION
This PR fixes backlog item https://github.com/orgs/hl7au/projects/28?pane=issue&itemId=232350265.

Align example ids & filenames for missing/suppressed data and no known examples.

Changes:
- rename masked examples to remove the resource name from the id
- rename the Condition noknown example to noneknown to align with the AllergyIntolerance No known allergy

No changes to the content of the examples. 