### PR TITLE
Apply date search param requirements to AU Core DocumentReference period search param (FHIR-57934)

### DIFF
--- a/input/intro-notes/StructureDefinition-au-core-documentreference-notes.md
+++ b/input/intro-notes/StructureDefinition-au-core-documentreference-notes.md
@@ -55,7 +55,7 @@
       <td>period</td>
       <td><b>MAY</b></td>
       <td><code>date</code></td>
-      <td></td>
+      <td>A requester <b>SHALL</b> provide a value precise to the second + time offset. A responder <b>SHALL</b> support a value precise to the second + time offset.<br/><br/>The requester <strong>SHALL</strong> support these search comparators <code>gt</code>, <code>lt</code>, <code>ge</code>, <code>le</code>. The responder <strong>SHALL</strong> support these search comparators <code>gt</code>, <code>lt</code>, <code>ge</code>, <code>le</code>.<br/><br/>The requester <strong>SHOULD</strong> support <code>multipleAnd</code>, and if <code>multipleAnd</code> is supported, <strong>SHALL</strong> support the search comparators <code>gt</code>, <code>lt</code>, <code>ge</code>, <code>le</code>. The responder <strong>SHOULD</strong> support <code>multipleAnd</code>, and if <code>multipleAnd</code> is supported, <strong>SHALL</strong> support the search comparators <code>gt</code>, <code>lt</code>, <code>ge</code>, <code>le</code>.</td>
     </tr>
     <tr>
       <td>type</td>
@@ -128,8 +128,10 @@ The following search parameters and search parameter combinations **SHOULD** be 
 
 1. **SHOULD** support searching using the combination of the **[`patient`](https://hl7.org/fhir/R4/documentreference.html#search)** and **[`type`](https://hl7.org/fhir/R4/documentreference.html#search)** and **[`period`](https://hl7.org/fhir/R4/documentreference.html#search)** search parameters:
     - **SHOULD** support chained searching of patient canonical identifier `patient.identifier` (e.g. `patient.identifier=[system|][code]`)
+    - **SHALL** support these `period` comparators: `gt,lt,ge,le`
+    - **SHOULD** support *[multipleAnd](http://hl7.org/fhir/R4/searchparameter-definitions.html#SearchParameter.multipleAnd)* search on `period` (e.g.`period=[date]&period=[date]&...`), and if *[multipleAnd](http://hl7.org/fhir/R4/searchparameter-definitions.html#SearchParameter.multipleAnd)* is supported, **SHALL** support the search comparators `gt,lt,ge,le`
 
-    `GET [base]/DocumentReference?patient={Type/}[id]&type={system|}[code]&period=[date]`
+    `GET [base]/DocumentReference?patient={Type/}[id]&type={system|}[code]&period={gt|lt|ge|le}[date]{&period={gt|lt|ge|le}[date]&...}`
 
     Example:
     

--- a/input/pagecontent/changes.md
+++ b/input/pagecontent/changes.md
@@ -6,9 +6,9 @@
 This change log documents the significant updates and resolutions implemented from version [3.0.0-ballot1](https://hl7.org.au/fhir/core/3.0.0-ballot1/index.html) to TBD. The list below includes substantive changes to mandatory and _Must Support_ elements inherited from AU Base.
 
 #### Changes in this version
-- [AU Core Requester CapabilityStatement](CapabilityStatement-au-core-requester.html) 
+- [AU Core Requester CapabilityStatement](CapabilityStatement-au-core-requester.html):
   - added existing AU Core date search parameter requirements to the DocumentReference period search parameter, including required precision and comparator support, and recommended multipleAnd support [AU Core: FHIR-57934](https://jira.hl7.org/browse/FHIR-57934)
-- [AU Core Responder CapabilityStatement](CapabilityStatement-au-core-responder.html)
+- [AU Core Responder CapabilityStatement](CapabilityStatement-au-core-responder.html):
   - added existing AU Core date search parameter requirements to the DocumentReference period search parameter, including required precision and comparator support, and recommended multipleAnd support [AU Core: FHIR-57934](https://jira.hl7.org/browse/FHIR-57934)
 
 ### Release 3.0.0-ballot1

--- a/input/pagecontent/changes.md
+++ b/input/pagecontent/changes.md
@@ -7,7 +7,7 @@ This change log documents the significant updates and resolutions implemented fr
 
 #### Changes in this version
 - [AU Core DocumentReference](StructureDefinition-au-core-documentreference.html):
-  - added support for comparators gt, le, lt, ge as SHALL, multipleAnd support as SHOULD and precision to the second + time offset as SHALL for period search parameter [AU Core: FHIR-57934](https://jira.hl7.org/browse/FHIR-57934)
+  - added the existing AU Core date search parameter requirements to the period search parameter, including required precision and comparator support, and recommended multipleAnd support [AU Core: FHIR-57934](https://jira.hl7.org/browse/FHIR-57934)
 
 ### Release 3.0.0-ballot1
 - Publication date: 2026-07-29

--- a/input/pagecontent/changes.md
+++ b/input/pagecontent/changes.md
@@ -6,8 +6,10 @@
 This change log documents the significant updates and resolutions implemented from version [3.0.0-ballot1](https://hl7.org.au/fhir/core/3.0.0-ballot1/index.html) to TBD. The list below includes substantive changes to mandatory and _Must Support_ elements inherited from AU Base.
 
 #### Changes in this version
-- [AU Core DocumentReference](StructureDefinition-au-core-documentreference.html):
-  - added the existing AU Core date search parameter requirements to the period search parameter, including required precision and comparator support, and recommended multipleAnd support [AU Core: FHIR-57934](https://jira.hl7.org/browse/FHIR-57934)
+- [AU Core Requester CapabilityStatement](CapabilityStatement-au-core-requester.html) 
+  - added existing AU Core date search parameter requirements to the DocumentReference period search parameter, including required precision and comparator support, and recommended multipleAnd support [AU Core: FHIR-57934](https://jira.hl7.org/browse/FHIR-57934)
+- [AU Core Responder CapabilityStatement](CapabilityStatement-au-core-responder.html)
+  - added existing AU Core date search parameter requirements to the DocumentReference period search parameter, including required precision and comparator support, and recommended multipleAnd support [AU Core: FHIR-57934](https://jira.hl7.org/browse/FHIR-57934)
 
 ### Release 3.0.0-ballot1
 - Publication date: 2026-07-29

--- a/input/pagecontent/changes.md
+++ b/input/pagecontent/changes.md
@@ -6,7 +6,8 @@
 This change log documents the significant updates and resolutions implemented from version [3.0.0-ballot1](https://hl7.org.au/fhir/core/3.0.0-ballot1/index.html) to TBD. The list below includes substantive changes to mandatory and _Must Support_ elements inherited from AU Base.
 
 #### Changes in this version
-
+- [AU Core DocumentReference](StructureDefinition-au-core-documentreference.html):
+  - added support for comparators gt, le, lt, ge as SHALL, multipleAnd support as SHOULD and precision to the second + time offset as SHALL for period search parameter [AU Core: FHIR-57934](https://jira.hl7.org/browse/FHIR-57934)
 
 ### Release 3.0.0-ballot1
 - Publication date: 2026-07-29

--- a/input/resources/au-core-requester.xml
+++ b/input/resources/au-core-requester.xml
@@ -624,6 +624,7 @@
 <name value="period"/>
 <definition value="http://hl7.org/fhir/SearchParameter/DocumentReference-period"/>
 <type value="date"/>
+<documentation value="The requester **SHALL** provide a value precise to the *second + time offset*.&#xA;&#xA;The responder **SHALL** support a value precise to the *second + time offset*. &#xA;&#xA;The requester **SHALL** support these search comparators `gt`, `lt`, `ge`, `le`.&#xA;&#xA;The responder **SHALL** support these search comparators `gt`, `lt`, `ge`, `le`.&#xa;&#xa;The requester **SHOULD** support `multipleAnd`, and if `multipleAnd` is supported, **SHALL** support the search comparators `gt`, `lt`, `ge`, `le`.&#xa;&#xa;The responder **SHOULD** support `multipleAnd`, and if `multipleAnd` is supported, **SHALL** support the search comparators `gt`, `lt`, `ge`, `le`."/>
 </searchParam>
 </resource>
 <!-- ENCOUNTER :: DONE -->

--- a/input/resources/au-core-responder.xml
+++ b/input/resources/au-core-responder.xml
@@ -623,6 +623,7 @@
 <name value="period"/>
 <definition value="http://hl7.org/fhir/SearchParameter/DocumentReference-period"/>
 <type value="date"/>
+<documentation value="The requester **SHALL** provide a value precise to the *second + time offset*.&#xA;&#xA;The responder **SHALL** support a value precise to the *second + time offset*. &#xA;&#xA;The requester **SHALL** support these search comparators `gt`, `lt`, `ge`, `le`.&#xA;&#xA;The responder **SHALL** support these search comparators `gt`, `lt`, `ge`, `le`.&#xa;&#xa;The requester **SHOULD** support `multipleAnd`, and if `multipleAnd` is supported, **SHALL** support the search comparators `gt`, `lt`, `ge`, `le`.&#xa;&#xa;The responder **SHOULD** support `multipleAnd`, and if `multipleAnd` is supported, **SHALL** support the search comparators `gt`, `lt`, `ge`, `le`."/>
 </searchParam>
 </resource>
 <!-- ENCOUNTER :: DONE -->


### PR DESCRIPTION
Applies [FHIR-57934](https://jira.hl7.org/browse/FHIR-57934)
* Add support for comparators, multipleAnd and precision to second + time offset in Requester and Responder CapStats to AU Core DocumentReference period search param
* Add to profile notes (table, optional search params)
* Change log entry