### PR TITLE
Correct reference search parameter type syntax (FHIR-58685)

### DIFF
--- a/input/includes/observation_notes.md
+++ b/input/includes/observation_notes.md
@@ -6,7 +6,7 @@ The following search parameters and search parameter combinations **SHALL** be s
     - **SHOULD** support chained searching of patient canonical identifier `patient.identifier` (e.g. `patient.identifier=[system|][code]`)
 
 
-    `GET [base]/Observation?patient={Type/}[id]&category={system|}[code]`
+    `GET [base]/Observation?patient={type/}[id]&category={system|}[code]`
 
     Example:
     
@@ -19,7 +19,7 @@ The following search parameters and search parameter combinations **SHALL** be s
     - **SHOULD** support *[multipleOr](http://hl7.org/fhir/R4/searchparameter-definitions.html#SearchParameter.multipleOr)* search on `code` (e.g. `code={system|}[code],{system|}[code],...`)
 
 
-    `GET [base]/Observation?patient={Type/}[id]&code={system|}[code]{,{system|}[code],...}`
+    `GET [base]/Observation?patient={type/}[id]&code={system|}[code]{,{system|}[code],...}`
 
     Example:
     
@@ -33,7 +33,7 @@ The following search parameters and search parameter combinations **SHALL** be s
     - **SHOULD** support *[multipleAnd](http://hl7.org/fhir/R4/searchparameter-definitions.html#SearchParameter.multipleAnd)* search on `date` (e.g. `date=[date]&date=[date]&...`)
 
 
-    `GET [base]/Observation?patient={Type/}[id]&category={system|}[code]&date={gt|lt|ge|le}[date]{&date={gt|lt|ge|le}[date]&...}`
+    `GET [base]/Observation?patient={type/}[id]&category={system|}[code]&date={gt|lt|ge|le}[date]{&date={gt|lt|ge|le}[date]&...}`
 
     Example:
     
@@ -61,7 +61,7 @@ The following search parameters and search parameter combinations **SHOULD** be 
     - **SHOULD** support chained searching of patient canonical identifier `patient.identifier` (e.g. `patient.identifier=[system|][code]`)
     - **SHALL** support *[multipleOr](http://hl7.org/fhir/R4/searchparameter-definitions.html#SearchParameter.multipleOr)* search on `status` (e.g. `status={system|}[code],{system|}[code],...`)
 
-    `GET [base]/Observation?patient={Type/}[id]&category={system|}[code]&status={system|}[code]{,{system|}[code],...}`
+    `GET [base]/Observation?patient={type/}[id]&category={system|}[code]&status={system|}[code]{,{system|}[code],...}`
 
     Example:
     
@@ -75,7 +75,7 @@ The following search parameters and search parameter combinations **SHOULD** be 
     - **SHALL** support these `date` comparators: `gt,lt,ge,le`
     - **SHOULD** support *[multipleAnd](http://hl7.org/fhir/R4/searchparameter-definitions.html#SearchParameter.multipleAnd)* search on `date` (e.g. `date=[date]&date=[date]&...`)
 
-    `GET [base]/Observation?patient={Type/}[id]&code={system|}[code]{,{system|}[code],...}&date={gt|lt|ge|le}[date]{&date={gt|lt|ge|le}[date]&...}`
+    `GET [base]/Observation?patient={type/}[id]&code={system|}[code]{,{system|}[code],...}&date={gt|lt|ge|le}[date]{&date={gt|lt|ge|le}[date]&...}`
 
     Example:
     

--- a/input/includes/observation_parameters.md
+++ b/input/includes/observation_parameters.md
@@ -42,7 +42,7 @@
         <td>patient</td>
         <td><b>MAY</b></td>
         <td><code>reference</code></td>
-        <td>The requester <b>SHALL</b> provide at least an id value and <b>MAY</b> provide both the Type and id values. The responder <b>SHALL</b> support both.<br/><br/>The requester <strong>SHOULD</strong> support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile. The responder <strong>SHOULD</strong> support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile.</td>
+        <td>The requester <b>SHALL</b> provide at least an id value and <b>MAY</b> provide both the type and id values. The responder <b>SHALL</b> support both.<br/><br/>The requester <strong>SHOULD</strong> support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile. The responder <strong>SHOULD</strong> support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile.</td>
   </tr>
   <tr>
         <td>category</td>

--- a/input/includes/observation_social-history_notes.md
+++ b/input/includes/observation_social-history_notes.md
@@ -6,7 +6,7 @@ The following search parameters and search parameter combinations **SHALL** be s
     - **SHOULD** support chained searching of patient canonical identifier `patient.identifier` (e.g. `patient.identifier=[system|][code]`)
 
 
-    `GET [base]/Observation?patient={Type/}[id]&category={system|}[code]`
+    `GET [base]/Observation?patient={type/}[id]&category={system|}[code]`
 
     Example:
     
@@ -21,7 +21,7 @@ The following search parameters and search parameter combinations **SHALL** be s
     - **SHOULD** support *[multipleAnd](http://hl7.org/fhir/R4/searchparameter-definitions.html#SearchParameter.multipleAnd)* search on `date` (e.g. `date=[date]&date=[date]&...`), and if *[multipleAnd](http://hl7.org/fhir/R4/searchparameter-definitions.html#SearchParameter.multipleAnd)* is supported, <strong>SHALL</strong> support the search comparators `gt,lt,ge,le`
 
 
-    `GET [base]/Observation?patient={Type/}[id]&category={system|}[code]&date={gt|lt|ge|le}[date]{&date={gt|lt|ge|le}[date]&...}`
+    `GET [base]/Observation?patient={type/}[id]&category={system|}[code]&date={gt|lt|ge|le}[date]{&date={gt|lt|ge|le}[date]&...}`
 
     Example:
     
@@ -34,7 +34,7 @@ The following search parameters and search parameter combinations **SHALL** be s
     - **SHOULD** support *[multipleOr](http://hl7.org/fhir/R4/searchparameter-definitions.html#SearchParameter.multipleOr)* search on `code` (e.g. `code={system|}[code],{system|}[code],...`)
 
 
-    `GET [base]/Observation?patient={Type/}[id]&code={system|}[code]{,{system|}[code],...}`
+    `GET [base]/Observation?patient={type/}[id]&code={system|}[code]{,{system|}[code],...}`
 
     Example:
     
@@ -64,7 +64,7 @@ The following search parameters and search parameter combinations **SHOULD** be 
     - **SHALL** support *[multipleOr](http://hl7.org/fhir/R4/searchparameter-definitions.html#SearchParameter.multipleOr)* search on `status` (e.g. `status={system|}[code],{system|}[code],...`)
 
 
-    `GET [base]/Observation?patient={Type/}[id]&category={system|}[code]&status={system|}[code]{,{system|}[code],...}`
+    `GET [base]/Observation?patient={type/}[id]&category={system|}[code]&status={system|}[code]{,{system|}[code],...}`
 
     Example:
     
@@ -79,7 +79,7 @@ The following search parameters and search parameter combinations **SHOULD** be 
     - **SHOULD** support *[multipleAnd](http://hl7.org/fhir/R4/searchparameter-definitions.html#SearchParameter.multipleAnd)* search on `date` (e.g. `date=[date]&date=[date]&...`), and if *[multipleAnd](http://hl7.org/fhir/R4/searchparameter-definitions.html#SearchParameter.multipleAnd)* is supported, <strong>SHALL</strong> support the search comparators `gt,lt,ge,le`
 
 
-    `GET [base]/Observation?patient={Type/}[id]&code={system|}[code]{,{system|}[code],...}&date={gt|lt|ge|le}[date]{&date={gt|lt|ge|le}[date]&...}`
+    `GET [base]/Observation?patient={type/}[id]&code={system|}[code]{,{system|}[code],...}&date={gt|lt|ge|le}[date]{&date={gt|lt|ge|le}[date]&...}`
 
     Example:
     

--- a/input/includes/observation_vitalsigns_notes.md
+++ b/input/includes/observation_vitalsigns_notes.md
@@ -6,7 +6,7 @@ The following search parameters and search parameter combinations **SHALL** be s
     - **SHOULD** support chained searching of patient canonical identifier `patient.identifier` (e.g. `patient.identifier=[system|][code]`)
 
 
-    `GET [base]/Observation?patient={Type/}[id]&category=vital-signs`
+    `GET [base]/Observation?patient={type/}[id]&category=vital-signs`
 
     Example:
     
@@ -20,7 +20,7 @@ The following search parameters and search parameter combinations **SHALL** be s
     - **SHOULD** support *[multipleAnd](http://hl7.org/fhir/R4/searchparameter-definitions.html#SearchParameter.multipleAnd)* search on `date` (e.g. `date=[date]&date=[date]&...`), and if *[multipleAnd](http://hl7.org/fhir/R4/searchparameter-definitions.html#SearchParameter.multipleAnd)* is supported, <strong>SHALL</strong> support the search comparators `gt,lt,ge,le`
 
 
-    `GET [base]/Observation?patient={Type/}[id]&category=vital-signs&date={gt|lt|ge|le}[date]{&date={gt|lt|ge|le}[date]&...}`
+    `GET [base]/Observation?patient={type/}[id]&category=vital-signs&date={gt|lt|ge|le}[date]{&date={gt|lt|ge|le}[date]&...}`
 
     Example:
     
@@ -33,7 +33,7 @@ The following search parameters and search parameter combinations **SHALL** be s
     - **SHOULD** support *[multipleOr](http://hl7.org/fhir/R4/searchparameter-definitions.html#SearchParameter.multipleOr)* search on `code` (e.g. `code={system|}[code],{system|}[code],...`)
 
 
-    `GET [base]/Observation?patient={Type/}[id]&code={system|}[code]{,{system|}[code],...}`
+    `GET [base]/Observation?patient={type/}[id]&code={system|}[code]{,{system|}[code],...}`
 
     Example:
     
@@ -63,7 +63,7 @@ The following search parameters and search parameter combinations **SHOULD** be 
     - **SHALL** support *[multipleOr](http://hl7.org/fhir/R4/searchparameter-definitions.html#SearchParameter.multipleOr)* search on `status` (e.g. `status={system|}[code],{system|}[code],...`)
 
 
-    `GET [base]/Observation?patient={Type/}[id]&category=vital-signs&status={system|}[code]{,{system|}[code],...}`
+    `GET [base]/Observation?patient={type/}[id]&category=vital-signs&status={system|}[code]{,{system|}[code],...}`
 
     Example:
     
@@ -79,7 +79,7 @@ The following search parameters and search parameter combinations **SHOULD** be 
     - **SHOULD** support *[multipleAnd](http://hl7.org/fhir/R4/searchparameter-definitions.html#SearchParameter.multipleAnd)* search on `date` (e.g. `date=[date]&date=[date]&...`), and if *[multipleAnd](http://hl7.org/fhir/R4/searchparameter-definitions.html#SearchParameter.multipleAnd)* is supported, <strong>SHALL</strong> support the search comparators `gt,lt,ge,le`
 
 
-    `GET [base]/Observation?patient={Type/}[id]&code={system|}[code]{,{system|}[code],...}&date={gt|lt|ge|le}[date]{&date={gt|lt|ge|le}[date]&...}`
+    `GET [base]/Observation?patient={type/}[id]&code={system|}[code]{,{system|}[code],...}&date={gt|lt|ge|le}[date]{&date={gt|lt|ge|le}[date]&...}`
 
     Example:
     

--- a/input/includes/observation_vitalsigns_parameters.md
+++ b/input/includes/observation_vitalsigns_parameters.md
@@ -42,7 +42,7 @@
         <td>patient</td>
         <td><b>MAY</b></td>
         <td><code>reference</code></td>
-        <td>The requester <b>SHALL</b> provide at least an id value and <b>MAY</b> provide both the Type and id values. The responder <b>SHALL</b> support both.<br/><br/>The requester <strong>SHOULD</strong> support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile. The responder <strong>SHOULD</strong> support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile.</td>
+        <td>The requester <b>SHALL</b> provide at least an id value and <b>MAY</b> provide both the type and id values. The responder <b>SHALL</b> support both.<br/><br/>The requester <strong>SHOULD</strong> support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile. The responder <strong>SHOULD</strong> support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile.</td>
   </tr>
   <tr>
         <td>category</td>

--- a/input/intro-notes/StructureDefinition-au-core-allergyintolerance-notes.md
+++ b/input/intro-notes/StructureDefinition-au-core-allergyintolerance-notes.md
@@ -13,7 +13,7 @@
         <td>patient</td>
         <td><b>SHALL</b></td>
         <td><code>reference</code></td>
-        <td>The requester <b>SHALL</b> provide at least an id value and <b>MAY</b> provide both the Type and id values. The responder <b>SHALL</b> support both.<br/><br/>The requester <b>SHOULD</b> support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile. The responder <b>SHOULD</b> support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile.</td>
+        <td>The requester <b>SHALL</b> provide at least an id value and <b>MAY</b> provide both the type and id values. The responder <b>SHALL</b> support both.<br/><br/>The requester <b>SHOULD</b> support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile. The responder <b>SHOULD</b> support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile.</td>
   </tr>
   <tr>
         <td>patient+clinical-status</td>
@@ -39,7 +39,7 @@ The following search parameters and search parameter combinations **SHALL** be s
     - **SHOULD** support chained searching of patient canonical identifier `patient.identifier` (e.g. `patient.identifier=[system|][code]`)
 
 
-    `GET [base]/AllergyIntolerance?patient={Type/}[id]` or optionally `GET [base]/AllergyIntolerance?patient.identifier=[system|][code]`
+    `GET [base]/AllergyIntolerance?patient={type/}[id]` or optionally `GET [base]/AllergyIntolerance?patient.identifier=[system|][code]`
 
     Example:
     
@@ -57,7 +57,7 @@ The following search parameters and search parameter combinations **SHOULD** be 
     - **SHOULD** support chained searching of patient canonical identifier `patient.identifier` (e.g. `patient.identifier=[system|][code]`)
 
 
-    `GET [base]/AllergyIntolerance?patient={Type/}[id]&clinical-status={system|}[code]{,{system|}[code],...}`
+    `GET [base]/AllergyIntolerance?patient={type/}[id]&clinical-status={system|}[code]{,{system|}[code],...}`
 
     Example:
     

--- a/input/intro-notes/StructureDefinition-au-core-composition-notes.md
+++ b/input/intro-notes/StructureDefinition-au-core-composition-notes.md
@@ -13,7 +13,7 @@
         <td>patient</td>
         <td><b>SHALL</b></td>
         <td><code>reference</code></td>
-        <td>The requester <b>SHALL</b> provide at least an id value and <b>MAY</b> provide both the Type and id values. The responder <b>SHALL</b> support both.<br/><br/>The requester <b>SHOULD</b> support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile. The responder <b>SHOULD</b> support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile.</td>
+        <td>The requester <b>SHALL</b> provide at least an id value and <b>MAY</b> provide both the type and id values. The responder <b>SHALL</b> support both.<br/><br/>The requester <b>SHOULD</b> support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile. The responder <b>SHOULD</b> support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile.</td>
   </tr>
   <tr>
         <td>patient+date</td>
@@ -63,7 +63,7 @@ The following search parameters and search parameter combinations **SHALL** be s
     - **SHOULD** support chained searching of patient canonical identifier `patient.identifier` (e.g. `patient.identifier=[system|][code]`)
 
 
-    `GET [base]/Composition?patient={Type/}[id]` or optionally `GET [base]/Composition?patient.identifier=[system|][code]`
+    `GET [base]/Composition?patient={type/}[id]` or optionally `GET [base]/Composition?patient.identifier=[system|][code]`
 
     Example:
     
@@ -79,7 +79,7 @@ The following search parameters and search parameter combinations **SHALL** be s
     - **SHOULD** support *[multipleAnd](http://hl7.org/fhir/R4/searchparameter-definitions.html#SearchParameter.multipleAnd)* search on `date` (e.g. `date=[date]&date=[date]&...`), and if *[multipleAnd](http://hl7.org/fhir/R4/searchparameter-definitions.html#SearchParameter.multipleAnd)* is supported, **SHALL** support the search comparators `gt,lt,ge,le`
 
 
-    `GET [base]/Composition?patient={Type/}[id]&date={gt|lt|ge|le}[date]{&date={gt|lt|ge|le}[date]&...}`
+    `GET [base]/Composition?patient={type/}[id]&date={gt|lt|ge|le}[date]{&date={gt|lt|ge|le}[date]&...}`
 
     Example:
     
@@ -92,7 +92,7 @@ The following search parameters and search parameter combinations **SHALL** be s
     - **SHOULD** support chained searching of patient canonical identifier `patient.identifier` (e.g. `patient.identifier=[system|][code]`)
 
 
-    `GET [base]/Composition?patient={Type/}[id]&type={system|}[code]`
+    `GET [base]/Composition?patient={type/}[id]&type={system|}[code]`
 
     Example:
     
@@ -109,7 +109,7 @@ The following search parameters and search parameter combinations **SHOULD** be 
     - **SHOULD** support chained searching of patient canonical identifier `patient.identifier` (e.g. `patient.identifier=[system|][code]`)
 
 
-    `GET [base]/Composition?patient={Type/}[id]&author={Type/}[id]`
+    `GET [base]/Composition?patient={type/}[id]&author={type/}[id]`
 
     Example:
     

--- a/input/intro-notes/StructureDefinition-au-core-condition-notes.md
+++ b/input/intro-notes/StructureDefinition-au-core-condition-notes.md
@@ -13,7 +13,7 @@
         <td>patient</td>
         <td><b>SHALL</b></td>
         <td><code>reference</code></td>
-        <td>The requester <b>SHALL</b> provide at least an id value and <b>MAY</b> provide both the Type and id values. The responder <b>SHALL</b> support both.<br/><br/>The requester <b>SHOULD</b> support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile. The responder <b>SHOULD</b> support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile.</td>
+        <td>The requester <b>SHALL</b> provide at least an id value and <b>MAY</b> provide both the type and id values. The responder <b>SHALL</b> support both.<br/><br/>The requester <b>SHOULD</b> support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile. The responder <b>SHOULD</b> support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile.</td>
   </tr>
   <tr>
         <td>patient+category</td>
@@ -80,7 +80,7 @@ The following search parameters and search parameter combinations **SHALL** be s
 1. **SHALL** support searching using the **[`patient`](https://hl7.org/fhir/R4/condition.html#search)** search parameter:
     - **SHOULD** support chained searching of patient canonical identifier `patient.identifier` (e.g. `patient.identifier=[system|][code]`)
 
-    `GET [base]/Condition?patient={Type/}[id]`
+    `GET [base]/Condition?patient={type/}[id]`
     or optionally  `GET [base]/Condition?patient.identifier=[system|][code]`
 
     Example:
@@ -94,7 +94,7 @@ The following search parameters and search parameter combinations **SHALL** be s
 1. **SHALL** support searching using the combination of the **[`patient`](https://hl7.org/fhir/R4/condition.html#search)** and **[`category`](https://hl7.org/fhir/R4/condition.html#search)** search parameters:
     - **SHOULD** support chained searching of patient canonical identifier `patient.identifier` (e.g. `patient.identifier=[system|][code]`)
 
-    `GET [base]/Condition?patient={Type/}[id]&category={system|}[code]`
+    `GET [base]/Condition?patient={type/}[id]&category={system|}[code]`
 
     Example:
     
@@ -105,7 +105,7 @@ The following search parameters and search parameter combinations **SHALL** be s
 1. **SHALL** support searching using the combination of the **[`patient`](https://hl7.org/fhir/R4/condition.html#search)** and **[`clinical-status`](https://hl7.org/fhir/R4/condition.html#search)** search parameters:
     - **SHOULD** support chained searching of patient canonical identifier `patient.identifier` (e.g. `patient.identifier=[system|][code]`)
 
-    `GET [base]/Condition?patient={Type/}[id]&clinical-status={system|}[code]`
+    `GET [base]/Condition?patient={type/}[id]&clinical-status={system|}[code]`
 
     Example:
     
@@ -121,7 +121,7 @@ The following search parameters and search parameter combinations **SHOULD** be 
 1. **SHOULD** support searching using the combination of the **[`patient`](https://hl7.org/fhir/R4/condition.html#search)** and **[`category`](https://hl7.org/fhir/R4/condition.html#search)** and **[`clinical-status`](https://hl7.org/fhir/R4/condition.html#search)** search parameters:
     - **SHOULD** support chained searching of patient canonical identifier `patient.identifier` (e.g. `patient.identifier=[system|][code]`)
 
-    `GET [base]/Condition?patient={Type/}[id]&category={system|}[code]&clinical-status={system|}[code]`
+    `GET [base]/Condition?patient={type/}[id]&category={system|}[code]&clinical-status={system|}[code]`
 
     Example:
     
@@ -133,7 +133,7 @@ The following search parameters and search parameter combinations **SHOULD** be 
     - **SHOULD** support chained searching of patient canonical identifier `patient.identifier` (e.g. `patient.identifier=[system|][code]`)
     - **SHOULD** support *[multipleOr](http://hl7.org/fhir/R4/searchparameter-definitions.html#SearchParameter.multipleOr)* search on `code` (e.g. `code={system|}[code],{system|}[code],...`)
 
-    `GET [base]/Condition?patient={Type/}[id]&code={system|}[code]{,{system|}[code],...}`
+    `GET [base]/Condition?patient={type/}[id]&code={system|}[code]{,{system|}[code],...}`
 
     Example:
     
@@ -146,7 +146,7 @@ The following search parameters and search parameter combinations **SHOULD** be 
     - **SHALL** support these `onset-date` comparators: `gt,lt,ge,le`
     - **SHOULD** support *[multipleAnd](http://hl7.org/fhir/R4/searchparameter-definitions.html#SearchParameter.multipleAnd)* search on `onset-date` (e.g. `onset-date=[date]&onset-date=[date]]&...`), and if *[multipleAnd](http://hl7.org/fhir/R4/searchparameter-definitions.html#SearchParameter.multipleAnd)* is supported, <strong>SHALL</strong> support the search comparators `gt,lt,ge,le`
 
-    `GET [base]/Condition?patient={Type/}[id]&onset-date={gt|lt|ge|le}[date]{&onset-date={gt|lt|ge|le}[date]&...}`
+    `GET [base]/Condition?patient={type/}[id]&onset-date={gt|lt|ge|le}[date]{&onset-date={gt|lt|ge|le}[date]&...}`
 
     Example:
     

--- a/input/intro-notes/StructureDefinition-au-core-diagnosticreport-notes.md
+++ b/input/intro-notes/StructureDefinition-au-core-diagnosticreport-notes.md
@@ -19,7 +19,7 @@
         <td>patient</td>
         <td><b>SHALL</b></td>
         <td><code>reference</code></td>
-        <td>The requester <b>SHALL</b> provide at least an id value and <b>MAY</b> provide both the Type and id values. The responder <b>SHALL</b> support both.<br/><br/>The requester <b>SHOULD</b> support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile. The responder <b>SHOULD</b> support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile.</td>
+        <td>The requester <b>SHALL</b> provide at least an id value and <b>MAY</b> provide both the type and id values. The responder <b>SHALL</b> support both.<br/><br/>The requester <b>SHOULD</b> support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile. The responder <b>SHOULD</b> support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile.</td>
   </tr>
   <tr>
         <td>patient+category</td>
@@ -108,7 +108,7 @@ The following search parameters and search parameter combinations **SHALL** be s
 1. **SHALL** support searching using the **[`patient`](https://hl7.org/fhir/R4/diagnosticreport.html#search)** search parameter:
     - **SHOULD** support chained searching of patient canonical identifier `patient.identifier` (e.g. `patient.identifier=[system|][code]`)
 
-    `GET [base]/DiagnosticReport?patient={Type/}[id]` or optionally `GET [base]/DiagnosticReport?patient.identifier=[system|][code]`
+    `GET [base]/DiagnosticReport?patient={type/}[id]` or optionally `GET [base]/DiagnosticReport?patient.identifier=[system|][code]`
 
     Example:
     
@@ -121,7 +121,7 @@ The following search parameters and search parameter combinations **SHALL** be s
 1. **SHALL** support searching using the combination of the **[`patient`](https://hl7.org/fhir/R4/diagnosticreport.html#search)** and **[`category`](https://hl7.org/fhir/R4/diagnosticreport.html#search)** search parameters:
     - **SHOULD** support chained searching of patient canonical identifier `patient.identifier` (e.g. `patient.identifier=[system|][code]`)
 
-    `GET [base]/DiagnosticReport?patient={Type/}[id]&category={system|}[code]` or optionally `GET [base]/DiagnosticReport?patient.identifier=[system|][code]&category={system|}[code]`
+    `GET [base]/DiagnosticReport?patient={type/}[id]&category={system|}[code]` or optionally `GET [base]/DiagnosticReport?patient.identifier=[system|][code]&category={system|}[code]`
 
     Example:
     
@@ -136,7 +136,7 @@ The following search parameters and search parameter combinations **SHALL** be s
      - **SHALL** support these `date` comparators: `gt,lt,ge,le`
     - **SHOULD** support *[multipleAnd](http://hl7.org/fhir/R4/searchparameter-definitions.html#SearchParameter.multipleAnd)* search on `date` (e.g. `date=[date]&date=[date]&...`), and if *[multipleAnd](http://hl7.org/fhir/R4/searchparameter-definitions.html#SearchParameter.multipleAnd)* is supported, **SHALL** support the search comparators `gt,lt,ge,le`
 
-    `GET [base]/DiagnosticReport?patient={Type/}[id]&category={system|}[code]&date={gt|lt|ge|le}[date]{&date={gt|lt|ge|le}[date]&...}` or optionally `GET [base]/DiagnosticReport?patient.identifier=[system|][code]&category={system|}[code]&date={gt|lt|ge|le}[date]{&date={gt|lt|ge|le}[date]&...}`
+    `GET [base]/DiagnosticReport?patient={type/}[id]&category={system|}[code]&date={gt|lt|ge|le}[date]{&date={gt|lt|ge|le}[date]&...}` or optionally `GET [base]/DiagnosticReport?patient.identifier=[system|][code]&category={system|}[code]&date={gt|lt|ge|le}[date]{&date={gt|lt|ge|le}[date]&...}`
 
     Example:
     
@@ -164,7 +164,7 @@ The following search parameters and search parameter combinations **SHOULD** be 
 1. **SHOULD** support searching using the combination of the **[`patient`](https://hl7.org/fhir/R4/diagnosticreport.html#search)** and **[`category`](https://hl7.org/fhir/R4/diagnosticreport.html#search)** and **[`status`](https://hl7.org/fhir/R4/diagnosticreport.html#search)** search parameters:
     - **SHOULD** support chained searching of patient canonical identifier `patient.identifier` (e.g. `patient.identifier=[system|][code]`)
 
-    `GET [base]/DiagnosticReport?patient={Type/}[id]&category={system|}[code]&status={system|}[code]` or optionally `GET [base]/DiagnosticReport?patient.identifier=[system|][code]&category={system|}[code]&status={system|}[code]`
+    `GET [base]/DiagnosticReport?patient={type/}[id]&category={system|}[code]&status={system|}[code]` or optionally `GET [base]/DiagnosticReport?patient.identifier=[system|][code]&category={system|}[code]&status={system|}[code]`
 
     Example:
     
@@ -177,7 +177,7 @@ The following search parameters and search parameter combinations **SHOULD** be 
 1. **SHOULD** support searching using the combination of the **[`patient`](https://hl7.org/fhir/R4/diagnosticreport.html#search)** and **[`code`](https://hl7.org/fhir/R4/diagnosticreport.html#search)** search parameters:
     - **SHOULD** support chained searching of patient canonical identifier `patient.identifier` (e.g. `patient.identifier=[system|][code]`)
 
-    `GET [base]/DiagnosticReport?patient={Type/}[id]&code={system|}[code]` or optionally `GET [base]/DiagnosticReport?patient.identifier=[system|][code]&code={system|}[code]`
+    `GET [base]/DiagnosticReport?patient={type/}[id]&code={system|}[code]` or optionally `GET [base]/DiagnosticReport?patient.identifier=[system|][code]&code={system|}[code]`
 
     Example:
     
@@ -192,7 +192,7 @@ The following search parameters and search parameter combinations **SHOULD** be 
     - **SHALL** support these `date` comparators: `gt,lt,ge,le`
     - **SHOULD** support *[multipleAnd](http://hl7.org/fhir/R4/searchparameter-definitions.html#SearchParameter.multipleAnd)* search on `date` (e.g. `date=[date]&date=[date]&...`), and if *[multipleAnd](http://hl7.org/fhir/R4/searchparameter-definitions.html#SearchParameter.multipleAnd)* is supported, **SHALL** support the search comparators `gt,lt,ge,le`
 
-    `GET [base]/DiagnosticReport?patient={Type/}[id]&code={system|}[code]&date={gt|lt|ge|le}[date]{&date={gt|lt|ge|le}[date]&...}` or optionally `GET [base]/DiagnosticReport?patient.identifier=[system|][code]&code={system|}[code]&date={gt|lt|ge|le}[date]{&date={gt|lt|ge|le}[date]&...}`
+    `GET [base]/DiagnosticReport?patient={type/}[id]&code={system|}[code]&date={gt|lt|ge|le}[date]{&date={gt|lt|ge|le}[date]&...}` or optionally `GET [base]/DiagnosticReport?patient.identifier=[system|][code]&code={system|}[code]&date={gt|lt|ge|le}[date]{&date={gt|lt|ge|le}[date]&...}`
 
     Example:
     
@@ -205,7 +205,7 @@ The following search parameters and search parameter combinations **SHOULD** be 
 1. **SHOULD** support searching using the combination of the **[`patient`](https://hl7.org/fhir/R4/diagnosticreport.html#search)** and **[`status`](https://hl7.org/fhir/R4/diagnosticreport.html#search)** search parameters:
     - **SHOULD** support chained searching of patient canonical identifier `patient.identifier` (e.g. `patient.identifier=[system|][code]`)
 
-    `GET [base]/DiagnosticReport?patient={Type/}[id]&status={system|}[code]` or optionally `GET [base]/DiagnosticReport?patient.identifier=[system|][code]&status={system|}[code]`
+    `GET [base]/DiagnosticReport?patient={type/}[id]&status={system|}[code]` or optionally `GET [base]/DiagnosticReport?patient.identifier=[system|][code]&status={system|}[code]`
 
     Example:
     

--- a/input/intro-notes/StructureDefinition-au-core-diagnosticresult-notes.md
+++ b/input/intro-notes/StructureDefinition-au-core-diagnosticresult-notes.md
@@ -8,7 +8,7 @@ The following search parameters and search parameter combinations **SHALL** be s
 1. **SHALL** support searching using the combination of the **[`patient`](https://hl7.org/fhir/R4/observation.html#search)** and **[`category`](https://hl7.org/fhir/R4/observation.html#search)** search parameters:
     - **SHOULD** support chained searching of patient canonical identifier `patient.identifier` (e.g. `patient.identifier=[system|][code]`)
 
-    `GET [base]/Observation?patient={Type/}[id]&category={system|}[code]`
+    `GET [base]/Observation?patient={type/}[id]&category={system|}[code]`
 
     Example:
     
@@ -20,7 +20,7 @@ The following search parameters and search parameter combinations **SHALL** be s
     - **SHOULD** support chained searching of patient canonical identifier `patient.identifier` (e.g. `patient.identifier=[system|][code]`)
     - **SHOULD** support *[multipleOr](http://hl7.org/fhir/R4/searchparameter-definitions.html#SearchParameter.multipleOr)* search on `code` (e.g. `code={system|}[code],{system|}[code],...`)
 
-    `GET [base]/Observation?patient={Type/}[id]&code={system|}[code]{,{system|}[code],...}`
+    `GET [base]/Observation?patient={type/}[id]&code={system|}[code]{,{system|}[code],...}`
 
     Example:
     
@@ -33,7 +33,7 @@ The following search parameters and search parameter combinations **SHALL** be s
     - **SHALL** support these `date` comparators: `gt,lt,ge,le`
      - **SHOULD** support *[multipleAnd](http://hl7.org/fhir/R4/searchparameter-definitions.html#SearchParameter.multipleAnd)* search on `date` (e.g. `date=[date]&date=[date]&...`), and if *[multipleAnd](http://hl7.org/fhir/R4/searchparameter-definitions.html#SearchParameter.multipleAnd)* is supported, <strong>SHALL</strong> support the search comparators `gt,lt,ge,le`
 
-    `GET [base]/Observation?patient={Type/}[id]&category={system|}[code]&date={gt|lt|ge|le}[date]{&date={gt|lt|ge|le}[date]&...}`
+    `GET [base]/Observation?patient={type/}[id]&category={system|}[code]&date={gt|lt|ge|le}[date]{&date={gt|lt|ge|le}[date]&...}`
 
     Example:
     
@@ -61,7 +61,7 @@ The following search parameters and search parameter combinations **SHOULD** be 
     - **SHOULD** support chained searching of patient canonical identifier `patient.identifier` (e.g. `patient.identifier=[system|][code]`)
     - **SHALL** support *[multipleOr](http://hl7.org/fhir/R4/searchparameter-definitions.html#SearchParameter.multipleOr)* search on `status` (e.g. `status={system|}[code],{system|}[code],...`)
 
-    `GET [base]/Observation?patient={Type/}[id]&category={system|}[code]&status={system|}[code]{,{system|}[code],...}`
+    `GET [base]/Observation?patient={type/}[id]&category={system|}[code]&status={system|}[code]{,{system|}[code],...}`
 
     Example:
     
@@ -75,7 +75,7 @@ The following search parameters and search parameter combinations **SHOULD** be 
     - **SHALL** support these `date` comparators: `gt,lt,ge,le`
     - **SHOULD** support *[multipleAnd](http://hl7.org/fhir/R4/searchparameter-definitions.html#SearchParameter.multipleAnd)* search on `date` (e.g. `date=[date]&date=[date]&...`), and if *[multipleAnd](http://hl7.org/fhir/R4/searchparameter-definitions.html#SearchParameter.multipleAnd)* is supported, <strong>SHALL</strong> support the search comparators `gt,lt,ge,le`
 
-    `GET [base]/Observation?patient={Type/}[id]&code={system|}[code]{,{system|}[code],...}&date={gt|lt|ge|le}[date]{&date={gt|lt|ge|le}[date]&...}`
+    `GET [base]/Observation?patient={type/}[id]&code={system|}[code]{,{system|}[code],...}&date={gt|lt|ge|le}[date]{&date={gt|lt|ge|le}[date]&...}`
 
     Example:
     

--- a/input/intro-notes/StructureDefinition-au-core-diagnosticresult-path-notes.md
+++ b/input/intro-notes/StructureDefinition-au-core-diagnosticresult-path-notes.md
@@ -8,7 +8,7 @@ The following search parameters and search parameter combinations **SHALL** be s
 1. **SHALL** support searching using the combination of the **[`patient`](https://hl7.org/fhir/R4/observation.html#search)** and **[`category`](https://hl7.org/fhir/R4/observation.html#search)** search parameters:
     - **SHOULD** support chained searching of patient canonical identifier `patient.identifier` (e.g. `patient.identifier=[system|][code]`)
 
-    `GET [base]/Observation?patient={Type/}[id]&category=http://terminology.hl7.org/CodeSystem/observation-category|laboratory`
+    `GET [base]/Observation?patient={type/}[id]&category=http://terminology.hl7.org/CodeSystem/observation-category|laboratory`
 
     Example:
     
@@ -20,7 +20,7 @@ The following search parameters and search parameter combinations **SHALL** be s
     - **SHOULD** support chained searching of patient canonical identifier `patient.identifier` (e.g. `patient.identifier=[system|][code]`)
     - **SHOULD** support *[multipleOr](http://hl7.org/fhir/R4/searchparameter-definitions.html#SearchParameter.multipleOr)* search on `code` (e.g. `code={system|}[code],{system|}[code],...`)
 
-    `GET [base]/Observation?patient={Type/}[id]&code={system|}[code]{,{system|}[code],...}`
+    `GET [base]/Observation?patient={type/}[id]&code={system|}[code]{,{system|}[code],...}`
 
     Example:
     
@@ -33,7 +33,7 @@ The following search parameters and search parameter combinations **SHALL** be s
     - **SHALL** support these `date` comparators: `gt,lt,ge,le`
     - **SHOULD** support *[multipleAnd](http://hl7.org/fhir/R4/searchparameter-definitions.html#SearchParameter.multipleAnd)* search on `date` (e.g. `date=[date]&date=[date]&...`), and if *[multipleAnd](http://hl7.org/fhir/R4/searchparameter-definitions.html#SearchParameter.multipleAnd)* is supported, <strong>SHALL</strong> support the search comparators `gt,lt,ge,le`
 
-    `GET [base]/Observation?patient={Type/}[id]&category=http://terminology.hl7.org/CodeSystem/observation-category|laboratory&date={gt|lt|ge|le}[date]{&date={gt|lt|ge|le}[date]&...}`
+    `GET [base]/Observation?patient={type/}[id]&category=http://terminology.hl7.org/CodeSystem/observation-category|laboratory&date={gt|lt|ge|le}[date]{&date={gt|lt|ge|le}[date]&...}`
 
     Example:
     
@@ -61,7 +61,7 @@ The following search parameters and search parameter combinations **SHOULD** be 
     - **SHOULD** support chained searching of patient canonical identifier `patient.identifier` (e.g. `patient.identifier=[system|][code]`)
     - **SHALL** support *[multipleOr](http://hl7.org/fhir/R4/searchparameter-definitions.html#SearchParameter.multipleOr)* search on `status` (e.g. `status={system|}[code],{system|}[code],...`)
 
-    `GET [base]/Observation?patient={Type/}[id]&category=http://terminology.hl7.org/CodeSystem/observation-category|laboratory&status={system|}[code]{,{system|}[code],...}`
+    `GET [base]/Observation?patient={type/}[id]&category=http://terminology.hl7.org/CodeSystem/observation-category|laboratory&status={system|}[code]{,{system|}[code],...}`
 
     Example:
     
@@ -75,7 +75,7 @@ The following search parameters and search parameter combinations **SHOULD** be 
     - **SHALL** support these `date` comparators: `gt,lt,ge,le`
     - **SHOULD** support *[multipleAnd](http://hl7.org/fhir/R4/searchparameter-definitions.html#SearchParameter.multipleAnd)* search on `date` (e.g. `date=[date]&date=[date]&...`), and if *[multipleAnd](http://hl7.org/fhir/R4/searchparameter-definitions.html#SearchParameter.multipleAnd)* is supported, <strong>SHALL</strong> support the search comparators `gt,lt,ge,le`
 
-    `GET [base]/Observation?patient={Type/}[id]&code={system|}[code]{,{system|}[code],...}&date={gt|lt|ge|le}[date]{&date={gt|lt|ge|le}[date]&...}`
+    `GET [base]/Observation?patient={type/}[id]&code={system|}[code]{,{system|}[code],...}&date={gt|lt|ge|le}[date]{&date={gt|lt|ge|le}[date]&...}`
 
     Example:
     

--- a/input/intro-notes/StructureDefinition-au-core-documentreference-notes.md
+++ b/input/intro-notes/StructureDefinition-au-core-documentreference-notes.md
@@ -13,7 +13,7 @@
       <td>patient</td>
       <td><b>SHALL</b></td>
       <td><code>reference</code></td>
-      <td>The requester <b>SHALL</b> provide at least an id value and <b>MAY</b> provide both the Type and id values. The responder <b>SHALL</b> support both.<br/><br/>The requester <b>SHOULD</b> support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile. The responder <b>SHOULD</b> support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile.</td>
+      <td>The requester <b>SHALL</b> provide at least an id value and <b>MAY</b> provide both the type and id values. The responder <b>SHALL</b> support both.<br/><br/>The requester <b>SHOULD</b> support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile. The responder <b>SHOULD</b> support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile.</td>
     </tr>
     <tr>
       <td>patient+type</td>
@@ -74,7 +74,7 @@ The following search parameters and search parameter combinations **SHALL** be s
 1. **SHALL** support searching using the **[`patient`](https://hl7.org/fhir/R4/documentreference.html#search)** search parameter:
     - **SHOULD** support chained searching of patient canonical identifier `patient.identifier` (e.g. `patient.identifier=[system|][code]`)
 
-    `GET [base]/DocumentReference?patient={Type/}[id]` or optionally `GET [base]/DocumentReference?patient.identifier=[system|][code]`
+    `GET [base]/DocumentReference?patient={type/}[id]` or optionally `GET [base]/DocumentReference?patient.identifier=[system|][code]`
 
     Example:
     
@@ -87,7 +87,7 @@ The following search parameters and search parameter combinations **SHALL** be s
 1. **SHALL** support searching using the combination of the **[`patient`](https://hl7.org/fhir/R4/documentreference.html#search)** and **[`type`](https://hl7.org/fhir/R4/documentreference.html#search)** search parameters:
     - **SHOULD** support chained searching of patient canonical identifier `patient.identifier` (e.g. `patient.identifier=[system|][code]`)
 
-    `GET [base]/DocumentReference?patient={Type/}[id]&type={system|}[code]`
+    `GET [base]/DocumentReference?patient={type/}[id]&type={system|}[code]`
 
     Example:
     
@@ -103,7 +103,7 @@ The following search parameters and search parameter combinations **SHOULD** be 
 1. **SHOULD** support searching using the combination of the **[`patient`](https://hl7.org/fhir/R4/documentreference.html#search)** and **[`author`](https://hl7.org/fhir/R4/documentreference.html#search)** search parameters:
     - **SHOULD** support chained searching of patient canonical identifier `patient.identifier` (e.g. `patient.identifier=[system|][code]`)
 
-    `GET [base]/DocumentReference?patient={Type/}[id]&author={Type/}[id]`
+    `GET [base]/DocumentReference?patient={type/}[id]&author={type/}[id]`
 
     Example:
     
@@ -117,7 +117,7 @@ The following search parameters and search parameter combinations **SHOULD** be 
     - **SHALL** support these `date` comparators: `gt,lt,ge,le`
     - **SHOULD** support *[multipleAnd](http://hl7.org/fhir/R4/searchparameter-definitions.html#SearchParameter.multipleAnd)* search on `date` (e.g.`date=[date]&date=[date]&...`), and if *[multipleAnd](http://hl7.org/fhir/R4/searchparameter-definitions.html#SearchParameter.multipleAnd)* is supported, **SHALL** support the search comparators `gt,lt,ge,le`
 
-    `GET [base]/DocumentReference?patient={Type/}[id]&type={system|}[code]&date={gt|lt|ge|le}[date]{&date={gt|lt|ge|le}[date]&...}`
+    `GET [base]/DocumentReference?patient={type/}[id]&type={system|}[code]&date={gt|lt|ge|le}[date]{&date={gt|lt|ge|le}[date]&...}`
 
     Example:
     
@@ -129,7 +129,7 @@ The following search parameters and search parameter combinations **SHOULD** be 
 1. **SHOULD** support searching using the combination of the **[`patient`](https://hl7.org/fhir/R4/documentreference.html#search)** and **[`type`](https://hl7.org/fhir/R4/documentreference.html#search)** and **[`period`](https://hl7.org/fhir/R4/documentreference.html#search)** search parameters:
     - **SHOULD** support chained searching of patient canonical identifier `patient.identifier` (e.g. `patient.identifier=[system|][code]`)
 
-    `GET [base]/DocumentReference?patient={Type/}[id]&type={system|}[code]&period=[date]`
+    `GET [base]/DocumentReference?patient={type/}[id]&type={system|}[code]&period=[date]`
 
     Example:
     

--- a/input/intro-notes/StructureDefinition-au-core-encounter-notes.md
+++ b/input/intro-notes/StructureDefinition-au-core-encounter-notes.md
@@ -13,7 +13,7 @@
         <td>patient</td>
         <td><b>SHALL</b></td>
         <td><code>reference</code></td>
-        <td>The requester <b>SHALL</b> provide at least an id value and <b>MAY</b> provide both the Type and id values. The responder <b>SHALL</b> support both.<br/><br/>The requester <b>SHOULD</b> support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile. The responder <b>SHOULD</b> support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile.</td>
+        <td>The requester <b>SHALL</b> provide at least an id value and <b>MAY</b> provide both the type and id values. The responder <b>SHALL</b> support both.<br/><br/>The requester <b>SHOULD</b> support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile. The responder <b>SHOULD</b> support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile.</td>
   </tr>
   <tr>
         <td>patient+date</td>
@@ -74,7 +74,7 @@ The following search parameters and search parameter combinations **SHALL** be s
 1. **SHALL** support searching using the **[`patient`](https://hl7.org/fhir/R4/encounter.html#search)** search parameter:
     - **SHOULD** support chained searching of patient canonical identifier `patient.identifier` (e.g. `patient.identifier=[system|][code]`)
 
-    `GET [base]/Encounter?patient={Type/}[id]` or optionally `GET [base]/Encounter?patient.identifier=[system|][code]`
+    `GET [base]/Encounter?patient={type/}[id]` or optionally `GET [base]/Encounter?patient.identifier=[system|][code]`
 
     Example:
     
@@ -89,7 +89,7 @@ The following search parameters and search parameter combinations **SHALL** be s
     - **SHALL** support these `date` comparators: `gt,lt,ge,le`
     - **SHOULD** support *[multipleAnd](http://hl7.org/fhir/R4/searchparameter-definitions.html#SearchParameter.multipleAnd)* search on `date` (e.g. `date=[date]&date=[date]&...`), and if *[multipleAnd](http://hl7.org/fhir/R4/searchparameter-definitions.html#SearchParameter.multipleAnd)* is supported, <strong>SHALL</strong> support the search comparators `gt,lt,ge,le`
 
-    `GET [base]/Encounter?patient={Type/}[id]&date={gt|lt|ge|le}[date]{&date={gt|lt|ge|le}[date]&...}`
+    `GET [base]/Encounter?patient={type/}[id]&date={gt|lt|ge|le}[date]{&date={gt|lt|ge|le}[date]&...}`
 
     Example:
     
@@ -105,7 +105,7 @@ The following search parameters and search parameter combinations **SHOULD** be 
 1. **SHOULD** support searching using the combination of the **[`patient`](https://hl7.org/fhir/R4/encounter.html#search)** and **[`class`](https://hl7.org/fhir/R4/encounter.html#search)** search parameters:
     - **SHOULD** support chained searching of patient canonical identifier `patient.identifier` (e.g. `patient.identifier=[system|][code]`)
 
-    `GET [base]/Encounter?patient={Type/}[id]&class={system|}[code]`
+    `GET [base]/Encounter?patient={type/}[id]&class={system|}[code]`
 
     Example:
     
@@ -116,7 +116,7 @@ The following search parameters and search parameter combinations **SHOULD** be 
 1. **SHOULD** support searching using the combination of the **[`patient`](https://hl7.org/fhir/R4/encounter.html#search)** and **[`location`](https://hl7.org/fhir/R4/encounter.html#search)** search parameters:
     - **SHOULD** support chained searching of patient canonical identifier `patient.identifier` (e.g. `patient.identifier=[system|][code]`)
 
-    `GET [base]/Encounter?patient={Type/}[id]&location={Type/}[id]`
+    `GET [base]/Encounter?patient={type/}[id]&location={type/}[id]`
 
     Example:
     
@@ -128,7 +128,7 @@ The following search parameters and search parameter combinations **SHOULD** be 
     - **SHOULD** support chained searching of patient canonical identifier `patient.identifier` (e.g. `patient.identifier=[system|][code]`)
     - **SHALL** support *[multipleOr](http://hl7.org/fhir/R4/searchparameter-definitions.html#SearchParameter.multipleOr)* search on `status` (e.g. `status={system|}[code],{system|}[code],...`)
 
-    `GET [base]/Encounter?patient={Type/}[id]&status={system|}[code]{,{system|}[code],...}`
+    `GET [base]/Encounter?patient={type/}[id]&status={system|}[code]{,{system|}[code],...}`
 
     Example:
     

--- a/input/intro-notes/StructureDefinition-au-core-encounter-notes.md
+++ b/input/intro-notes/StructureDefinition-au-core-encounter-notes.md
@@ -55,7 +55,7 @@
         <td>location</td>
         <td><b>MAY</b></td>
         <td><code>reference</code></td>
-        <td>The requester <b>SHALL</b> provide at least an id value and <b>MAY</b> provide both the Type and id values. The responder <b>SHALL</b> support both.</td>
+        <td>The requester <b>SHALL</b> provide at least an id value and <b>MAY</b> provide both the type and id values. The responder <b>SHALL</b> support both.</td>
   </tr>
   <tr>
         <td>status</td>

--- a/input/intro-notes/StructureDefinition-au-core-immunization-notes.md
+++ b/input/intro-notes/StructureDefinition-au-core-immunization-notes.md
@@ -13,7 +13,7 @@
         <td>patient</td>
         <td><b>SHALL</b></td>
         <td><code>reference</code></td>
-        <td>The requester <b>SHALL</b> provide at least an id value and <b>MAY</b> provide both the Type and id values. The responder <b>SHALL</b> support both.<br/><br/>The requester <b>SHOULD</b> support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile. The responder <b>SHOULD</b> support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile.</td>
+        <td>The requester <b>SHALL</b> provide at least an id value and <b>MAY</b> provide both the type and id values. The responder <b>SHALL</b> support both.<br/><br/>The requester <b>SHOULD</b> support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile. The responder <b>SHOULD</b> support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile.</td>
   </tr>
   <tr>
         <td>patient+status</td>
@@ -62,7 +62,7 @@ The following search parameters and search parameter combinations **SHALL** be s
 1. **SHALL** support searching using the **[`patient`](https://hl7.org/fhir/R4/immunization.html#search)** search parameter:
     - **SHOULD** support chained searching of patient canonical identifier `patient.identifier` (e.g. `patient.identifier=[system|][code]`)
 
-    `GET [base]/Immunization?patient={Type/}[id]` or optionally `GET [base]/Immunization?patient.identifier=[system|][code]`
+    `GET [base]/Immunization?patient={type/}[id]` or optionally `GET [base]/Immunization?patient.identifier=[system|][code]`
 
     Example:
     
@@ -75,7 +75,7 @@ The following search parameters and search parameter combinations **SHALL** be s
 1. **SHALL** support searching using the combination of the **[`patient`](https://hl7.org/fhir/R4/immunization.html#search)** and **[`status`](https://hl7.org/fhir/R4/immunization.html#search)** search parameters:
     - **SHOULD** support chained searching of patient canonical identifier `patient.identifier` (e.g. `patient.identifier=[system|][code]`)
 
-    `GET [base]/Immunization?patient={Type/}[id]&status={system|}[code]{,{system|}[code],...}`
+    `GET [base]/Immunization?patient={type/}[id]&status={system|}[code]{,{system|}[code],...}`
 
     Example:
     
@@ -94,7 +94,7 @@ The following search parameters and search parameter combinations **SHOULD** be 
     - **SHALL** support these `date` comparators: `gt,lt,ge,le`
     - **SHOULD** support *[multipleAnd](http://hl7.org/fhir/R4/searchparameter-definitions.html#SearchParameter.multipleAnd)* search on `date` (e.g. `date=[date]&date=[date]&...`), and if *[multipleAnd](http://hl7.org/fhir/R4/searchparameter-definitions.html#SearchParameter.multipleAnd)* is supported, <strong>SHALL</strong> support the search comparators `gt,lt,ge,le`
 
-    `GET [base]/Immunization?patient={Type/}[id]&date={gt|lt|ge|le}[date]{&date={gt|lt|ge|le}[date]&...}`
+    `GET [base]/Immunization?patient={type/}[id]&date={gt|lt|ge|le}[date]{&date={gt|lt|ge|le}[date]&...}`
 
     Example:
     

--- a/input/intro-notes/StructureDefinition-au-core-medicationdispense-notes.md
+++ b/input/intro-notes/StructureDefinition-au-core-medicationdispense-notes.md
@@ -13,7 +13,7 @@
         <td>patient</td>
         <td><b>SHALL</b></td>
         <td><code>reference</code></td>
-        <td>The requester <b>SHALL</b> provide at least an id value and <b>MAY</b> provide both the Type and id values. The responder <b>SHALL</b> support both.<br/><br/>The requester <b>SHOULD</b> support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile. The responder <b>SHOULD</b> support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile.</td>
+        <td>The requester <b>SHALL</b> provide at least an id value and <b>MAY</b> provide both the type and id values. The responder <b>SHALL</b> support both.<br/><br/>The requester <b>SHOULD</b> support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile. The responder <b>SHOULD</b> support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile.</td>
   </tr>
     <tr>
         <td>patient+status</td>
@@ -45,7 +45,7 @@ The following search parameters and search parameter combinations **SHALL** be s
     - **SHOULD** support chained searching of patient canonical identifier `patient.identifier` (e.g. `patient.identifier=[system|][code]`)
 
  
-    `GET [base]/MedicationDispense?patient={Type/}[id]` or optionally `GET [base]/MedicationDispense?patient.identifier=[system|][code]`
+    `GET [base]/MedicationDispense?patient={type/}[id]` or optionally `GET [base]/MedicationDispense?patient.identifier=[system|][code]`
 
     Example:
     
@@ -64,7 +64,7 @@ The following search parameters and search parameter combinations **SHOULD** be 
     - **SHALL** support *[multipleOr](http://hl7.org/fhir/R4/searchparameter-definitions.html#SearchParameter.multipleOr)* search on `status` (e.g. `status={system|}[code],{system|}[code],...`)
 
 
-    `GET [base]/MedicationDispense?patient={Type/}[id]&status={system|}[code]{,{system|}[code],...}`
+    `GET [base]/MedicationDispense?patient={type/}[id]&status={system|}[code]{,{system|}[code],...}`
 
     Example:
     

--- a/input/intro-notes/StructureDefinition-au-core-medicationrequest-notes.md
+++ b/input/intro-notes/StructureDefinition-au-core-medicationrequest-notes.md
@@ -13,7 +13,7 @@
         <td>patient</td>
         <td><b>SHALL</b></td>
         <td><code>reference</code></td>
-        <td>The requester <b>SHALL</b> provide at least an id value and <b>MAY</b> provide both the Type and id values. The responder <b>SHALL</b> support both.<br/><br/>The requester <b>SHOULD</b> support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile. The responder <b>SHOULD</b> support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile.</td>
+        <td>The requester <b>SHALL</b> provide at least an id value and <b>MAY</b> provide both the type and id values. The responder <b>SHALL</b> support both.<br/><br/>The requester <b>SHOULD</b> support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile. The responder <b>SHOULD</b> support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile.</td>
   </tr>
     <tr>
         <td>patient+status</td>
@@ -76,7 +76,7 @@ The following search parameters and search parameter combinations **SHALL** be s
     - **SHOULD** support chained searching of patient canonical identifier `patient.identifier` (e.g. `patient.identifier=[system|][code]`)
 
  
-    `GET [base]/MedicationRequest?patient={Type/}[id]` or optionally `GET [base]/MedicationRequest?patient.identifier=[system|][code]`
+    `GET [base]/MedicationRequest?patient={type/}[id]` or optionally `GET [base]/MedicationRequest?patient.identifier=[system|][code]`
 
     Example:
     
@@ -93,7 +93,7 @@ The following search parameters and search parameter combinations **SHALL** be s
     - **SHALL** support *[multipleOr](http://hl7.org/fhir/R4/searchparameter-definitions.html#SearchParameter.multipleOr)* search on `status` (e.g. `status={system|}[code],{system|}[code],...`)
 
 
-    `GET [base]/MedicationRequest?patient={Type/}[id]&status={system|}[code]{,{system|}[code],...}`
+    `GET [base]/MedicationRequest?patient={type/}[id]&status={system|}[code]{,{system|}[code],...}`
 
     Example:
     
@@ -126,7 +126,7 @@ The following search parameters and search parameter combinations **SHOULD** be 
     - **SHOULD** support *[multipleAnd](http://hl7.org/fhir/R4/searchparameter-definitions.html#SearchParameter.multipleAnd)* search on `authoredon` (e.g. `authoredon=[date]&authoredon=[date]&...`), and if *[multipleAnd](http://hl7.org/fhir/R4/searchparameter-definitions.html#SearchParameter.multipleAnd)* is supported, <strong>SHALL</strong> support the search comparators `gt,lt,ge,le`
 
 
-    `GET [base]/MedicationRequest?patient={Type/}[id]&intent={system|}[code]&authoredon={gt|lt|ge|le}[date]{&authoredon={gt|lt|ge|le}[date]&...}`
+    `GET [base]/MedicationRequest?patient={type/}[id]&intent={system|}[code]&authoredon={gt|lt|ge|le}[date]{&authoredon={gt|lt|ge|le}[date]&...}`
 
     Example:
     
@@ -139,7 +139,7 @@ The following search parameters and search parameter combinations **SHOULD** be 
     - **SHOULD** support chained searching of patient canonical identifier `patient.identifier` (e.g. `patient.identifier=[system|][code]`)
 
 
-    `GET [base]/MedicationRequest?patient={Type/}[id]&intent={system|}[code]`
+    `GET [base]/MedicationRequest?patient={type/}[id]&intent={system|}[code]`
 
     Example:
     
@@ -153,7 +153,7 @@ The following search parameters and search parameter combinations **SHOULD** be 
     - **SHALL** support *[multipleOr](http://hl7.org/fhir/R4/searchparameter-definitions.html#SearchParameter.multipleOr)* search on `status` (e.g. `status={system|}[code],{system|}[code],...`)
 
 
-    `GET [base]/MedicationRequest?patient={Type/}[id]&intent={system|}[code]&status={system|}[code]{,{system|}[code],...}`
+    `GET [base]/MedicationRequest?patient={type/}[id]&intent={system|}[code]&status={system|}[code]{,{system|}[code],...}`
 
     Example:
     

--- a/input/intro-notes/StructureDefinition-au-core-medicationstatement-notes.md
+++ b/input/intro-notes/StructureDefinition-au-core-medicationstatement-notes.md
@@ -13,7 +13,7 @@
         <td>patient</td>
         <td><b>SHALL</b></td>
         <td><code>reference</code></td>
-        <td>The requester <b>SHALL</b> provide at least an id value and <b>MAY</b> provide both the Type and id values. The responder <b>SHALL</b> support both.<br/><br/>The requester <b>SHOULD</b> support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile. The responder <b>SHOULD</b> support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile.</td>
+        <td>The requester <b>SHALL</b> provide at least an id value and <b>MAY</b> provide both the type and id values. The responder <b>SHALL</b> support both.<br/><br/>The requester <b>SHOULD</b> support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile. The responder <b>SHOULD</b> support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile.</td>
   </tr>
   <tr>
         <td>patient+status</td>
@@ -57,7 +57,7 @@ The following search parameters and search parameter combinations **SHALL** be s
     - **SHOULD** support these **[`_include`](http://hl7.org/fhir/R4/search.html#include)** parameters: `MedicationStatement:medication`
     - **SHOULD** support chained searching of patient canonical identifier `patient.identifier` (e.g. `patient.identifier=[system|][code]`)
 
-    `GET [base]/MedicationStatement?patient={Type/}[id]` or optionally `GET [base]/MedicationStatement?patient.identifier=[system|][code]`
+    `GET [base]/MedicationStatement?patient={type/}[id]` or optionally `GET [base]/MedicationStatement?patient.identifier=[system|][code]`
 
     Example:
     
@@ -74,7 +74,7 @@ The following search parameters and search parameter combinations **SHALL** be s
     - **SHALL** support *[multipleOr](http://hl7.org/fhir/R4/searchparameter-definitions.html#SearchParameter.multipleOr)* search on `status` (e.g. `status={system|}[code],{system|}[code],...`)
 
 
-    `GET [base]/MedicationStatement?patient={Type/}[id]&status={system|}[code]{,{system|}[code],...}`
+    `GET [base]/MedicationStatement?patient={type/}[id]&status={system|}[code]{,{system|}[code],...}`
 
     Example:
     
@@ -108,7 +108,7 @@ The following search parameters and search parameter combinations **SHOULD** be 
     - **SHOULD** support *[multipleAnd](http://hl7.org/fhir/R4/searchparameter-definitions.html#SearchParameter.multipleAnd)* search on `effective` (e.g. `effective=[date]&effective=[date]&...`)
     
 
-    `GET [base]/MedicationStatement?patient={Type/}[id]&effective={gt|lt|ge|le}[date]{&effective={gt|lt|ge|le}[date]&...}`
+    `GET [base]/MedicationStatement?patient={type/}[id]&effective={gt|lt|ge|le}[date]{&effective={gt|lt|ge|le}[date]&...}`
 
     Example:
     

--- a/input/intro-notes/StructureDefinition-au-core-practitionerrole-notes.md
+++ b/input/intro-notes/StructureDefinition-au-core-practitionerrole-notes.md
@@ -19,7 +19,7 @@
         <td>practitioner</td>
         <td><b>SHALL</b></td>
         <td><code>reference</code></td>
-        <td>The requester <b>SHALL</b> provide at least an id value and <b>MAY</b> provide both the Type and id values. The responder <b>SHALL</b> support both.<br/><br/>The requester <b>SHOULD</b> support chained search practitioner.identifier using a HPI-I identifier as defined in the AU Core Practitioner profile. The responder <b>SHOULD</b> support chained search practitioner.identifier using a HPI-I identifier as defined in the AU Core Practitioner profile.</td>
+        <td>The requester <b>SHALL</b> provide at least an id value and <b>MAY</b> provide both the type and id values. The responder <b>SHALL</b> support both.<br/><br/>The requester <b>SHOULD</b> support chained search practitioner.identifier using a HPI-I identifier as defined in the AU Core Practitioner profile. The responder <b>SHOULD</b> support chained search practitioner.identifier using a HPI-I identifier as defined in the AU Core Practitioner profile.</td>
   </tr>
   <tr>
         <td>_id</td>
@@ -68,7 +68,7 @@ The following search parameters **SHALL** be supported:
     - **SHOULD** support chained searching of practitioner canonical identifier `practitioner.identifier` (e.g. `practitioner.identifier=[system|][code]`)
     - **SHOULD** support these **[`_include`](http://hl7.org/fhir/R4/search.html#include)** parameters: `PractitionerRole:practitioner`
 
-    `GET [base]/PractitionerRole?practitioner={Type/}[id]` 
+    `GET [base]/PractitionerRole?practitioner={type/}[id]` 
     or optionally `GET [base]/PractitionerRole?practitioner.identifier=[system|][code]`
 
     Example:

--- a/input/intro-notes/StructureDefinition-au-core-practitionerrole-notes.md
+++ b/input/intro-notes/StructureDefinition-au-core-practitionerrole-notes.md
@@ -43,7 +43,7 @@
         <td>organization</td>
         <td><b>MAY</b></td>
         <td><code>reference</code></td>
-        <td>The requester <b>SHALL</b> provide at least an id value and <b>MAY</b> provide both the Type and id values. The responder <b>SHALL</b> support both.</td>
+        <td>The requester <b>SHALL</b> provide at least an id value and <b>MAY</b> provide both the type and id values. The responder <b>SHALL</b> support both.</td>
   </tr>
  </tbody>
 </table>

--- a/input/intro-notes/StructureDefinition-au-core-procedure-notes.md
+++ b/input/intro-notes/StructureDefinition-au-core-procedure-notes.md
@@ -13,7 +13,7 @@
         <td>patient</td>
         <td><b>SHALL</b></td>
         <td><code>reference</code></td>
-        <td>The requester <b>SHALL</b> provide at least an id value and <b>MAY</b> provide both the Type and id values. The responder <b>SHALL</b> support both.<br/><br/>The requester <b>SHOULD</b> support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile. The responder <b>SHOULD</b> support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile.</td>
+        <td>The requester <b>SHALL</b> provide at least an id value and <b>MAY</b> provide both the type and id values. The responder <b>SHALL</b> support both.<br/><br/>The requester <b>SHOULD</b> support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile. The responder <b>SHOULD</b> support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile.</td>
   </tr>
   <tr>
         <td>patient+date</td>
@@ -62,7 +62,7 @@ The following search parameters and search parameter combinations **SHALL** be s
 1. **SHALL** support searching using the **[`patient`](https://hl7.org/fhir/R4/procedure.html#search)** search parameter:
     - **SHOULD** support chained searching of patient canonical identifier `patient.identifier` (e.g. `patient.identifier=[system|][code]`)
 
-    `GET [base]/Procedure?patient={Type/}[id]` or optionally `GET [base]/Procedure?patient.identifier=[system|][code]`
+    `GET [base]/Procedure?patient={type/}[id]` or optionally `GET [base]/Procedure?patient.identifier=[system|][code]`
 
     Example:
     
@@ -77,7 +77,7 @@ The following search parameters and search parameter combinations **SHALL** be s
     - **SHALL** support these `date` comparators: `gt,lt,ge,le`
     - **SHOULD** support *[multipleAnd](http://hl7.org/fhir/R4/searchparameter-definitions.html#SearchParameter.multipleAnd)* search on `date` (e.g. `date=[date]&date=[date]&...`), and if *[multipleAnd](http://hl7.org/fhir/R4/searchparameter-definitions.html#SearchParameter.multipleAnd)* is supported, <strong>SHALL</strong> support the search comparators `gt,lt,ge,le`
 
-    `GET [base]/Procedure?patient={Type/}[id]&date={gt|lt|ge|le}[date]{&date={gt|lt|ge|le}[date]&...}`
+    `GET [base]/Procedure?patient={type/}[id]&date={gt|lt|ge|le}[date]{&date={gt|lt|ge|le}[date]&...}`
 
     Example:
     
@@ -97,7 +97,7 @@ The following search parameters and search parameter combinations **SHOULD** be 
     - **SHALL** support these `date` comparators: `gt,lt,ge,le`
     - **SHOULD** support *[multipleAnd](http://hl7.org/fhir/R4/searchparameter-definitions.html#SearchParameter.multipleAnd)* search on `date` (e.g. `date=[date]&date=[date]&...`), and if *[multipleAnd](http://hl7.org/fhir/R4/searchparameter-definitions.html#SearchParameter.multipleAnd)* is supported, <strong>SHALL</strong> support the search comparators `gt,lt,ge,le`
 
-    `GET [base]/Procedure?patient={Type/}[id]&code={system|}[code]{,{system|}[code],...}&date={gt|lt|ge|le}[date]{&date={gt|lt|ge|le}[date]&...}`
+    `GET [base]/Procedure?patient={type/}[id]&code={system|}[code]{,{system|}[code],...}&date={gt|lt|ge|le}[date]{&date={gt|lt|ge|le}[date]&...}`
 
     Example:
     
@@ -110,7 +110,7 @@ The following search parameters and search parameter combinations **SHOULD** be 
     - **SHOULD** support chained searching of patient canonical identifier `patient.identifier` (e.g. `patient.identifier=[system|][code]`)
     - **SHALL** support *[multipleOr](http://hl7.org/fhir/R4/searchparameter-definitions.html#SearchParameter.multipleOr)* search on `status` (e.g. `status={system|}[code],{system|}[code],...`)
 
-    `GET [base]/Procedure?patient={Type/}[id]&status={system|}[code]{,{system|}[code],...}`
+    `GET [base]/Procedure?patient={type/}[id]&status={system|}[code]{,{system|}[code],...}`
 
     Example:
     

--- a/input/intro-notes/StructureDefinition-au-core-relatedperson-notes.md
+++ b/input/intro-notes/StructureDefinition-au-core-relatedperson-notes.md
@@ -13,7 +13,7 @@
         <td>patient</td>
         <td><b>SHALL</b></td>
         <td><code>reference</code></td>
-        <td>The requester <b>SHALL</b> provide at least an id value and <b>MAY</b> provide both the Type and id values. The responder <b>SHALL</b> support both.<br/><br/>The requester <b>SHOULD</b> support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile. The responder <b>SHOULD</b> support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile.
+        <td>The requester <b>SHALL</b> provide at least an id value and <b>MAY</b> provide both the type and id values. The responder <b>SHALL</b> support both.<br/><br/>The requester <b>SHOULD</b> support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile. The responder <b>SHOULD</b> support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile.
         </td>
   </tr>
     <tr>
@@ -58,7 +58,7 @@ The following search parameters and search parameter combinations **SHALL** be s
 1. **SHALL** support searching using the **[`patient`](https://hl7.org/fhir/R4/relatedperson.html#search)** search parameter:
     - **SHOULD** support chained searching of patient canonical identifier `patient.identifier` (e.g. `patient.identifier=[system|][code]`)
 
-    `GET [base]/RelatedPerson?patient={Type/}[id]` or optionally `GET [base]/RelatedPerson?patient.identifier=[system|][code]`
+    `GET [base]/RelatedPerson?patient={type/}[id]` or optionally `GET [base]/RelatedPerson?patient.identifier=[system|][code]`
 
     Example:
     
@@ -86,7 +86,7 @@ The following search parameters and search parameter combinations **SHOULD** be 
 1. **SHOULD** support searching using the combination of the **[`patient`](https://hl7.org/fhir/R4/relatedperson.html#search)** and **[`relationship`](https://hl7.org/fhir/R4/relatedperson.html#search)** search parameters:
     - **SHOULD** support chained searching of patient canonical identifier `patient.identifier` (e.g. `patient.identifier=[system|][code]`)
 
-    `GET [base]/RelatedPerson?patient={Type/}[id]&relationship={system|}[code]`
+    `GET [base]/RelatedPerson?patient={type/}[id]&relationship={system|}[code]`
 
     Example:
     
@@ -98,7 +98,7 @@ The following search parameters and search parameter combinations **SHOULD** be 
 1. **SHOULD** support searching using the combination of the **[`patient`](https://hl7.org/fhir/R4/relatedperson.html#search)** and **[`name`](https://hl7.org/fhir/R4/relatedperson.html#search)** search parameters:
     - **SHOULD** support chained searching of patient canonical identifier `patient.identifier` (e.g. `patient.identifier=[system|][code]`)
 
-    `GET [base]/RelatedPerson?patient={Type/}[id]&name=[string]`
+    `GET [base]/RelatedPerson?patient={type/}[id]&name=[string]`
 
     Example:
 

--- a/input/resources/au-core-requester.xml
+++ b/input/resources/au-core-requester.xml
@@ -100,7 +100,7 @@
 <name value="patient"/>
 <definition value="http://hl7.org.au/fhir/core/SearchParameter/au-core-clinical-patient"/>
 <type value="reference"/>
-<documentation value="The requester **SHALL** provide at least an id value and **MAY** provide both the Type and id values.&#xa;&#xa;The responder **SHALL** support both.&#xa;&#xa;The requester **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile.&#xa;&#xa;The responder **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile."/>
+<documentation value="The requester **SHALL** provide at least an id value and **MAY** provide both the type and id values.&#xa;&#xa;The responder **SHALL** support both.&#xa;&#xa;The requester **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile.&#xa;&#xa;The responder **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile."/>
 </searchParam>
 </resource>
 <!-- CARETEAM :: DONE -->
@@ -177,7 +177,7 @@
 <name value="patient"/>
 <definition value="http://hl7.org.au/fhir/core/SearchParameter/au-core-clinical-patient"/>
 <type value="reference"/>
-<documentation value="The requester **SHALL** provide at least an id value and **MAY** provide both the Type and id values.&#xa;&#xa;The responder **SHALL** support both.&#xa;&#xa;The requester **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile.&#xa;&#xa;The responder **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile."/>
+<documentation value="The requester **SHALL** provide at least an id value and **MAY** provide both the type and id values.&#xa;&#xa;The responder **SHALL** support both.&#xa;&#xa;The requester **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile.&#xa;&#xa;The responder **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile."/>
 </searchParam>
 <searchParam>
 <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
@@ -332,7 +332,7 @@
 <name value="patient"/>
 <definition value="http://hl7.org.au/fhir/core/SearchParameter/au-core-clinical-patient"/>
 <type value="reference"/>
-<documentation value="The requester **SHALL** provide at least an id value and **MAY** provide both the Type and id values.&#xa;&#xa;The responder **SHALL** support both.&#xa;&#xa;The requester **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile.&#xa;&#xa;The responder **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile."/>
+<documentation value="The requester **SHALL** provide at least an id value and **MAY** provide both the type and id values.&#xa;&#xa;The responder **SHALL** support both.&#xa;&#xa;The requester **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile.&#xa;&#xa;The responder **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile."/>
 </searchParam>
 </resource>
 <!-- DEVICE :: DONE -->
@@ -442,7 +442,7 @@
 <name value="patient"/>
 <definition value="http://hl7.org.au/fhir/core/SearchParameter/au-core-clinical-patient"/>
 <type value="reference"/>
-<documentation value="The requester **SHALL** provide at least an id value and **MAY** provide both the Type and id values.&#xa;&#xa;The responder **SHALL** support both.&#xa;&#xa;The requester **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile.&#xa;&#xa;The responder **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile."/>
+<documentation value="The requester **SHALL** provide at least an id value and **MAY** provide both the type and id values.&#xa;&#xa;The responder **SHALL** support both.&#xa;&#xa;The requester **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile.&#xa;&#xa;The responder **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile."/>
 </searchParam>
 <searchParam>
 <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
@@ -589,7 +589,7 @@
 <name value="patient"/>
 <definition value="http://hl7.org.au/fhir/core/SearchParameter/au-core-clinical-patient"/>
 <type value="reference"/>
-<documentation value="The requester **SHALL** provide at least an id value and **MAY** provide both the Type and id values.&#xa;&#xa;The responder **SHALL** support both.&#xa;&#xa;The requester **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile.&#xa;&#xa;The responder **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile."/>
+<documentation value="The requester **SHALL** provide at least an id value and **MAY** provide both the type and id values.&#xa;&#xa;The responder **SHALL** support both.&#xa;&#xa;The requester **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile.&#xa;&#xa;The responder **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile."/>
 </searchParam>
 <searchParam>
 <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
@@ -720,7 +720,7 @@
 <name value="location"/>
 <definition value="http://hl7.org/fhir/SearchParameter/Encounter-location"/>
 <type value="reference"/>
-<documentation value="The requester **SHALL** provide at least an id value and **MAY** provide both the Type and id values.&#xa;&#xa;The responder **SHALL** support both."/>
+<documentation value="The requester **SHALL** provide at least an id value and **MAY** provide both the type and id values.&#xa;&#xa;The responder **SHALL** support both."/>
 </searchParam>
 <searchParam>
 <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
@@ -738,7 +738,7 @@
 <name value="patient"/>
 <definition value="http://hl7.org.au/fhir/core/SearchParameter/au-core-clinical-patient"/>
 <type value="reference"/>
-<documentation value="The requester **SHALL** provide at least an id value and **MAY** provide both the Type and id values.&#xa;&#xa;The responder **SHALL** support both.&#xa;&#xa;The requester **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile.&#xa;&#xa;The responder **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile."/>
+<documentation value="The requester **SHALL** provide at least an id value and **MAY** provide both the type and id values.&#xa;&#xa;The responder **SHALL** support both.&#xa;&#xa;The requester **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile.&#xa;&#xa;The responder **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile."/>
 </searchParam>
 </resource>
 <!-- ENDPOINT :: DONE -->
@@ -962,7 +962,7 @@
 <name value="patient"/>
 <definition value="http://hl7.org.au/fhir/core/SearchParameter/au-core-clinical-patient"/>
 <type value="reference"/>
-<documentation value="The requester **SHALL** provide at least an id value and **MAY** provide both the Type and id values.&#xa;&#xa;The responder **SHALL** support both.&#xa;&#xa;The requester **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile.&#xa;&#xa;The responder **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile."/>
+<documentation value="The requester **SHALL** provide at least an id value and **MAY** provide both the type and id values.&#xa;&#xa;The responder **SHALL** support both.&#xa;&#xa;The requester **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile.&#xa;&#xa;The responder **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile."/>
 </searchParam>
 </resource>
 <!-- LOCATION :: DONE -->
@@ -1103,7 +1103,7 @@
 <name value="patient"/>
 <definition value="http://hl7.org.au/fhir/core/SearchParameter/au-core-clinical-patient"/>
 <type value="reference"/>
-<documentation value="The requester **SHALL** provide at least an id value and **MAY** provide both the Type and id values.&#xa;&#xa;The responder **SHALL** support both.&#xa;&#xa;The requester **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile.&#xa;&#xa;The responder **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile."/>
+<documentation value="The requester **SHALL** provide at least an id value and **MAY** provide both the type and id values.&#xa;&#xa;The responder **SHALL** support both.&#xa;&#xa;The requester **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile.&#xa;&#xa;The responder **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile."/>
 </searchParam>
 <searchParam>
 <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
@@ -1236,7 +1236,7 @@
 <name value="patient"/>
 <definition value="http://hl7.org.au/fhir/core/SearchParameter/au-core-clinical-patient"/>
 <type value="reference"/>
-<documentation value="The requester **SHALL** provide at least an id value and **MAY** provide both the Type and id values.&#xa;&#xa;The responder **SHALL** support both.&#xa;&#xa;The requester **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile.&#xa;&#xa;The responder **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile."/>
+<documentation value="The requester **SHALL** provide at least an id value and **MAY** provide both the type and id values.&#xa;&#xa;The responder **SHALL** support both.&#xa;&#xa;The requester **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile.&#xa;&#xa;The responder **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile."/>
 </searchParam>
 </resource>
 <!-- MEDICATIONSTATEMENT :: DONE -->
@@ -1324,7 +1324,7 @@
 <name value="patient"/>
 <definition value="http://hl7.org.au/fhir/core/SearchParameter/au-core-clinical-patient"/>
 <type value="reference"/>
-<documentation value="The requester **SHALL** provide at least an id value and **MAY** provide both the Type and id values.&#xa;&#xa;The responder **SHALL** support both.&#xa;&#xa;The requester **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile.&#xa;&#xa;The responder **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile."/>
+<documentation value="The requester **SHALL** provide at least an id value and **MAY** provide both the type and id values.&#xa;&#xa;The responder **SHALL** support both.&#xa;&#xa;The requester **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile.&#xa;&#xa;The responder **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile."/>
 </searchParam>
 </resource>
 <!-- OBSERVATION :: DONE -->
@@ -1513,7 +1513,7 @@
 <name value="patient"/>
 <definition value="http://hl7.org.au/fhir/core/SearchParameter/au-core-clinical-patient"/>
 <type value="reference"/>
-<documentation value="The requester **SHALL** provide at least an id value and **MAY** provide both the Type and id values.&#xa;&#xa;The responder **SHALL** support both.&#xa;&#xa;The requester **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile.&#xa;&#xa;The responder **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile."/>
+<documentation value="The requester **SHALL** provide at least an id value and **MAY** provide both the type and id values.&#xa;&#xa;The responder **SHALL** support both.&#xa;&#xa;The requester **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile.&#xa;&#xa;The responder **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile."/>
 </searchParam>
 </resource>
 <!-- ORGANIZATION :: DONE -->
@@ -1820,7 +1820,7 @@
 <name value="practitioner"/>
 <definition value="http://hl7.org.au/fhir/core/SearchParameter/au-core-practitionerrole-practitioner"/>
 <type value="reference"/>
-<documentation value="The requester **SHALL** provide at least an id value and **MAY** provide both the Type and id values.&#xa;&#xa;The responder **SHALL** support both.&#xa;&#xa;The requester **SHOULD** support chained search practitioner.identifier using a HPI-I identifier as defined in the AU Core Practitioner profile.&#xa;&#xa;The responder **SHOULD** support chained search practitioner.identifier using a HPI-I identifier as defined in the AU Core Practitioner profile."/>
+<documentation value="The requester **SHALL** provide at least an id value and **MAY** provide both the type and id values.&#xa;&#xa;The responder **SHALL** support both.&#xa;&#xa;The requester **SHOULD** support chained search practitioner.identifier using a HPI-I identifier as defined in the AU Core Practitioner profile.&#xa;&#xa;The responder **SHOULD** support chained search practitioner.identifier using a HPI-I identifier as defined in the AU Core Practitioner profile."/>
 </searchParam>
 <searchParam>
 <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
@@ -1847,7 +1847,7 @@
 <name value="organization"/>
 <definition value="http://hl7.org/fhir/SearchParameter/PractitionerRole-organization"/>
 <type value="reference"/>
-<documentation value="The requester **SHALL** provide at least an id value and **MAY** provide both the Type and id values.&#xa;&#xa;The responder **SHALL** support both."/>
+<documentation value="The requester **SHALL** provide at least an id value and **MAY** provide both the type and id values.&#xa;&#xa;The responder **SHALL** support both."/>
 </searchParam>
 </resource>
 <!-- PROCEDURE :: DONE -->
@@ -1945,7 +1945,7 @@
 <name value="patient"/>
 <definition value="http://hl7.org.au/fhir/core/SearchParameter/au-core-clinical-patient"/>
 <type value="reference"/>
-<documentation value="The requester **SHALL** provide at least an id value and **MAY** provide both the Type and id values.&#xa;&#xa;The responder **SHALL** support both.&#xa;&#xa;The requester **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile.&#xa;&#xa;The responder **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile."/>
+<documentation value="The requester **SHALL** provide at least an id value and **MAY** provide both the type and id values.&#xa;&#xa;The responder **SHALL** support both.&#xa;&#xa;The requester **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile.&#xa;&#xa;The responder **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile."/>
 </searchParam>
 </resource>
 <!-- RELATED PERSON :: DONE -->
@@ -2027,7 +2027,7 @@
 <name value="patient"/>
 <definition value="http://hl7.org/fhir/SearchParameter/RelatedPerson-patient"/>
 <type value="reference"/>
-<documentation value="The requester **SHALL** provide at least an id value and **MAY** provide both the Type and id values.&#xa;&#xa;The responder **SHALL** support both.&#xa;&#xa;The requester **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile.&#xa;&#xa;The responder **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile."/>
+<documentation value="The requester **SHALL** provide at least an id value and **MAY** provide both the type and id values.&#xa;&#xa;The responder **SHALL** support both.&#xa;&#xa;The requester **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile.&#xa;&#xa;The responder **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile."/>
 </searchParam>
 </resource>
 <!-- SPECIMEN :: DONE -->

--- a/input/resources/au-core-responder.xml
+++ b/input/resources/au-core-responder.xml
@@ -99,7 +99,7 @@
 <name value="patient"/>
 <definition value="http://hl7.org.au/fhir/core/SearchParameter/au-core-clinical-patient"/>
 <type value="reference"/>
-<documentation value="The requester **SHALL** provide at least an id value and **MAY** provide both the Type and id values.&#xa;&#xa;The responder **SHALL** support both.&#xa;&#xa;The requester **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile.&#xa;&#xa;The responder **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile."/>
+<documentation value="The requester **SHALL** provide at least an id value and **MAY** provide both the type and id values.&#xa;&#xa;The responder **SHALL** support both.&#xa;&#xa;The requester **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile.&#xa;&#xa;The responder **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile."/>
 </searchParam>
 </resource>
 <!-- CARETEAM :: DONE -->
@@ -176,7 +176,7 @@
 <name value="patient"/>
 <definition value="http://hl7.org.au/fhir/core/SearchParameter/au-core-clinical-patient"/>
 <type value="reference"/>
-<documentation value="The requester **SHALL** provide at least an id value and **MAY** provide both the Type and id values.&#xa;&#xa;The responder **SHALL** support both.&#xa;&#xa;The requester **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile.&#xa;&#xa;The responder **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile."/>
+<documentation value="The requester **SHALL** provide at least an id value and **MAY** provide both the type and id values.&#xa;&#xa;The responder **SHALL** support both.&#xa;&#xa;The requester **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile.&#xa;&#xa;The responder **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile."/>
 </searchParam>
 <searchParam>
 <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
@@ -331,7 +331,7 @@
 <name value="patient"/>
 <definition value="http://hl7.org.au/fhir/core/SearchParameter/au-core-clinical-patient"/>
 <type value="reference"/>
-<documentation value="The requester **SHALL** provide at least an id value and **MAY** provide both the Type and id values.&#xa;&#xa;The responder **SHALL** support both.&#xa;&#xa;The requester **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile.&#xa;&#xa;The responder **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile."/>
+<documentation value="The requester **SHALL** provide at least an id value and **MAY** provide both the type and id values.&#xa;&#xa;The responder **SHALL** support both.&#xa;&#xa;The requester **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile.&#xa;&#xa;The responder **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile."/>
 </searchParam>
 </resource>
 <!-- DEVICE :: DONE -->
@@ -441,7 +441,7 @@
 <name value="patient"/>
 <definition value="http://hl7.org.au/fhir/core/SearchParameter/au-core-clinical-patient"/>
 <type value="reference"/>
-<documentation value="The requester **SHALL** provide at least an id value and **MAY** provide both the Type and id values.&#xa;&#xa;The responder **SHALL** support both.&#xa;&#xa;The requester **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile.&#xa;&#xa;The responder **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile."/>
+<documentation value="The requester **SHALL** provide at least an id value and **MAY** provide both the type and id values.&#xa;&#xa;The responder **SHALL** support both.&#xa;&#xa;The requester **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile.&#xa;&#xa;The responder **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile."/>
 </searchParam>
 <searchParam>
 <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
@@ -588,7 +588,7 @@
 <name value="patient"/>
 <definition value="http://hl7.org.au/fhir/core/SearchParameter/au-core-clinical-patient"/>
 <type value="reference"/>
-<documentation value="The requester **SHALL** provide at least an id value and **MAY** provide both the Type and id values.&#xa;&#xa;The responder **SHALL** support both.&#xa;&#xa;The requester **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile.&#xa;&#xa;The responder **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile."/>
+<documentation value="The requester **SHALL** provide at least an id value and **MAY** provide both the type and id values.&#xa;&#xa;The responder **SHALL** support both.&#xa;&#xa;The requester **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile.&#xa;&#xa;The responder **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile."/>
 </searchParam>
 <searchParam>
 <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
@@ -719,7 +719,7 @@
 <name value="location"/>
 <definition value="http://hl7.org/fhir/SearchParameter/Encounter-location"/>
 <type value="reference"/>
-<documentation value="The requester **SHALL** provide at least an id value and **MAY** provide both the Type and id values.&#xa;&#xa;The responder **SHALL** support both."/>
+<documentation value="The requester **SHALL** provide at least an id value and **MAY** provide both the type and id values.&#xa;&#xa;The responder **SHALL** support both."/>
 </searchParam>
 <searchParam>
 <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
@@ -737,7 +737,7 @@
 <name value="patient"/>
 <definition value="http://hl7.org.au/fhir/core/SearchParameter/au-core-clinical-patient"/>
 <type value="reference"/>
-<documentation value="The requester **SHALL** provide at least an id value and **MAY** provide both the Type and id values.&#xa;&#xa;The responder **SHALL** support both.&#xa;&#xa;The requester **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile.&#xa;&#xa;The responder **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile."/>
+<documentation value="The requester **SHALL** provide at least an id value and **MAY** provide both the type and id values.&#xa;&#xa;The responder **SHALL** support both.&#xa;&#xa;The requester **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile.&#xa;&#xa;The responder **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile."/>
 </searchParam>
 </resource>
 <!-- ENDPOINT :: DONE -->
@@ -961,7 +961,7 @@
 <name value="patient"/>
 <definition value="http://hl7.org.au/fhir/core/SearchParameter/au-core-clinical-patient"/>
 <type value="reference"/>
-<documentation value="The requester **SHALL** provide at least an id value and **MAY** provide both the Type and id values.&#xa;&#xa;The responder **SHALL** support both.&#xa;&#xa;The requester **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile.&#xa;&#xa;The responder **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile."/>
+<documentation value="The requester **SHALL** provide at least an id value and **MAY** provide both the type and id values.&#xa;&#xa;The responder **SHALL** support both.&#xa;&#xa;The requester **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile.&#xa;&#xa;The responder **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile."/>
 </searchParam>
 </resource><!-- LOCATION :: DONE -->
 <resource>
@@ -1100,7 +1100,7 @@
 <name value="patient"/>
 <definition value="http://hl7.org.au/fhir/core/SearchParameter/au-core-clinical-patient"/>
 <type value="reference"/>
-<documentation value="The requester **SHALL** provide at least an id value and **MAY** provide both the Type and id values.&#xa;&#xa;The responder **SHALL** support both.&#xa;&#xa;The requester **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile.&#xa;&#xa;The responder **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile."/>
+<documentation value="The requester **SHALL** provide at least an id value and **MAY** provide both the type and id values.&#xa;&#xa;The responder **SHALL** support both.&#xa;&#xa;The requester **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile.&#xa;&#xa;The responder **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile."/>
 </searchParam>
 <searchParam>
 <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
@@ -1233,7 +1233,7 @@
 <name value="patient"/>
 <definition value="http://hl7.org.au/fhir/core/SearchParameter/au-core-clinical-patient"/>
 <type value="reference"/>
-<documentation value="The requester **SHALL** provide at least an id value and **MAY** provide both the Type and id values.&#xa;&#xa;The responder **SHALL** support both.&#xa;&#xa;The requester **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile.&#xa;&#xa;The responder **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile."/>
+<documentation value="The requester **SHALL** provide at least an id value and **MAY** provide both the type and id values.&#xa;&#xa;The responder **SHALL** support both.&#xa;&#xa;The requester **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile.&#xa;&#xa;The responder **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile."/>
 </searchParam>
 </resource>
 <!-- MEDICATIONSTATEMENT :: DONE -->
@@ -1321,7 +1321,7 @@
 <name value="patient"/>
 <definition value="http://hl7.org.au/fhir/core/SearchParameter/au-core-clinical-patient"/>
 <type value="reference"/>
-<documentation value="The requester **SHALL** provide at least an id value and **MAY** provide both the Type and id values.&#xa;&#xa;The responder **SHALL** support both.&#xa;&#xa;The requester **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile.&#xa;&#xa;The responder **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile."/>
+<documentation value="The requester **SHALL** provide at least an id value and **MAY** provide both the type and id values.&#xa;&#xa;The responder **SHALL** support both.&#xa;&#xa;The requester **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile.&#xa;&#xa;The responder **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile."/>
 </searchParam>
 </resource>
 <!-- OBSERVATION :: DONE -->
@@ -1510,7 +1510,7 @@
 <name value="patient"/>
 <definition value="http://hl7.org.au/fhir/core/SearchParameter/au-core-clinical-patient"/>
 <type value="reference"/>
-<documentation value="The requester **SHALL** provide at least an id value and **MAY** provide both the Type and id values.&#xa;&#xa;The responder **SHALL** support both.&#xa;&#xa;The requester **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile.&#xa;&#xa;The responder **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile."/>
+<documentation value="The requester **SHALL** provide at least an id value and **MAY** provide both the type and id values.&#xa;&#xa;The responder **SHALL** support both.&#xa;&#xa;The requester **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile.&#xa;&#xa;The responder **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile."/>
 </searchParam>
 </resource><!-- ORGANIZATION :: DONE -->
 <resource>
@@ -1814,7 +1814,7 @@
 <name value="practitioner"/>
 <definition value="http://hl7.org.au/fhir/core/SearchParameter/au-core-practitionerrole-practitioner"/>
 <type value="reference"/>
-<documentation value="The requester **SHALL** provide at least an id value and **MAY** provide both the Type and id values.&#xa;&#xa;The responder **SHALL** support both.&#xa;&#xa;The requester **SHOULD** support chained search practitioner.identifier using a HPI-I identifier as defined in the AU Core Practitioner profile.&#xa;&#xa;The responder **SHOULD** support chained search practitioner.identifier using a HPI-I identifier as defined in the AU Core Practitioner profile."/>
+<documentation value="The requester **SHALL** provide at least an id value and **MAY** provide both the type and id values.&#xa;&#xa;The responder **SHALL** support both.&#xa;&#xa;The requester **SHOULD** support chained search practitioner.identifier using a HPI-I identifier as defined in the AU Core Practitioner profile.&#xa;&#xa;The responder **SHOULD** support chained search practitioner.identifier using a HPI-I identifier as defined in the AU Core Practitioner profile."/>
 </searchParam>
 <searchParam>
 <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
@@ -1841,7 +1841,7 @@
 <name value="organization"/>
 <definition value="http://hl7.org/fhir/SearchParameter/PractitionerRole-organization"/>
 <type value="reference"/>
-<documentation value="The requester **SHALL** provide at least an id value and **MAY** provide both the Type and id values.&#xa;&#xa;The responder **SHALL** support both."/>
+<documentation value="The requester **SHALL** provide at least an id value and **MAY** provide both the type and id values.&#xa;&#xa;The responder **SHALL** support both."/>
 </searchParam>
 </resource><!-- PROCEDURE :: DONE -->
 <resource>
@@ -1938,7 +1938,7 @@
 <name value="patient"/>
 <definition value="http://hl7.org.au/fhir/core/SearchParameter/au-core-clinical-patient"/>
 <type value="reference"/>
-<documentation value="The requester **SHALL** provide at least an id value and **MAY** provide both the Type and id values.&#xa;&#xa;The responder **SHALL** support both.&#xa;&#xa;The requester **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile.&#xa;&#xa;The responder **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile."/>
+<documentation value="The requester **SHALL** provide at least an id value and **MAY** provide both the type and id values.&#xa;&#xa;The responder **SHALL** support both.&#xa;&#xa;The requester **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile.&#xa;&#xa;The responder **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile."/>
 </searchParam>
 </resource>
 <!-- RELATED PERSON :: DONE -->
@@ -2020,7 +2020,7 @@
 <name value="patient"/>
 <definition value="http://hl7.org/fhir/SearchParameter/RelatedPerson-patient"/>
 <type value="reference"/>
-<documentation value="The requester **SHALL** provide at least an id value and **MAY** provide both the Type and id values.&#xa;&#xa;The responder **SHALL** support both.&#xa;&#xa;The requester **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile.&#xa;&#xa;The responder **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile."/>
+<documentation value="The requester **SHALL** provide at least an id value and **MAY** provide both the type and id values.&#xa;&#xa;The responder **SHALL** support both.&#xa;&#xa;The requester **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile.&#xa;&#xa;The responder **SHOULD** support chained search patient.identifier using IHI, Medicare Number, and DVA Number identifiers as defined in the AU Core Patient profile."/>
 </searchParam>
 </resource>
 <!-- SPECIMEN :: DONE -->


### PR DESCRIPTION
This PR provides fix for [FHIR-58685](https://jira.hl7.org/browse/FHIR-58685).

Corrects the reference search parameter guidance across affected AU Core profiles. Changes to
- use "type" instead of "Type"
- search syntax from "{Type/}[id]" to "{type/}[id]"