### PR TITLE
Clarify search param requirements for MedicationDispense 'prescription' and '_include=MedicationDispense:medication  (FHIR-57858, FHIR-57894)

### DIFF
--- a/input/intro-notes/StructureDefinition-au-core-medicationdispense-intro.md
+++ b/input/intro-notes/StructureDefinition-au-core-medicationdispense-intro.md
@@ -14,6 +14,7 @@ The following are supported usage scenarios for this profile:
 - MedicationDispense resources can represent a medication using either a code as `MedicationDispense.medicationCodeableConcept`, or reference a [Medication](http://hl7.org/fhir/R4/medication.html) resource using `MedicationDispense.medicationReference`.
   - Responders are not required to support both a code and a reference, but **SHALL** support *at least one* of these methods
   - When referencing a Medication resource, it is preferred the resource is [contained](http://hl7.org/fhir/R4/references.html#contained) but it may be an external resource
+  - If an external reference to a Medication resource is used, the responder **SHALL** support the `_include` parameter for searching this element
   - A requester **SHALL** support all methods
 - When populating `MedicationDispense.medicationCodeableConcept` responders **SHALL** correctly populate `MedicationDispense.medicationCodeableConcept.coding` with either a code from [Australian Medication](https://healthterminologies.gov.au/fhir/ValueSet/australian-medication-1) or [PBS Item Codes](https://build.fhir.org/ig/hl7au/au-fhir-base//ValueSet-pbs-item.html), or both, if a coded value is known and **MAY** populate with a code from another code system.
   - Responders **MAY** populate with only text if no coded value is known.

--- a/input/intro-notes/StructureDefinition-au-core-medicationdispense-notes.md
+++ b/input/intro-notes/StructureDefinition-au-core-medicationdispense-notes.md
@@ -31,7 +31,7 @@
         <td>prescription</td>
         <td><b>MAY</b></td>
         <td><code>reference</code></td>
-        <td></td>
+        <td>The requester <b>SHALL</b> provide at least an id value and <b>MAY</b> provide both the Type and id values. The responder <b>SHALL</b> support both.</td>
   </tr>
  </tbody>
 </table>
@@ -43,6 +43,7 @@ The following search parameters and search parameter combinations **SHALL** be s
 
 1. **SHALL** support searching using the **[`patient`](https://hl7.org/fhir/R4/medicationdispense.html#search)** search parameter:
     - **SHOULD** support chained searching of patient canonical identifier `patient.identifier` (e.g. `patient.identifier=[system|][code]`)
+    - **SHOULD** support these **[`_include`](http://hl7.org/fhir/R4/search.html#include)** parameters: `MedicationDispense:medication`
 
  
     `GET [base]/MedicationDispense?patient={Type/}[id]` or optionally `GET [base]/MedicationDispense?patient.identifier=[system|][code]`
@@ -50,8 +51,9 @@ The following search parameters and search parameter combinations **SHALL** be s
     Example:
     
       1. GET [base]/MedicationDispense?patient=5678
+      1. GET [base]/MedicationDispense?patient=5678&amp;_include=MedicationDispense:medication
       1. GET [base]/MedicationDispense?patient.identifier=http://ns.electronichealth.net.au/id/medicare-number\|32788511952
-      1. GET [base]/MedicationDispense?patient.identifier=http://ns.electronichealth.net.au/id/hi/ihi/1.0\|8003608833357361 
+      1. GET [base]/MedicationDispense?patient.identifier=http://ns.electronichealth.net.au/id/hi/ihi/1.0\|8003608833357361
 
     *Implementation Notes:* Fetches a bundle of all MedicationDispense resources for the specified patient ([how to search by reference](http://hl7.org/fhir/R4/search.html#reference) and [how to search by token](http://hl7.org/fhir/R4/search.html#token))
 
@@ -61,6 +63,7 @@ The following search parameters and search parameter combinations **SHOULD** be 
 
 1. **SHOULD** support searching using the combination of the **[`patient`](https://hl7.org/fhir/R4/medicationdispense.html#search)** and **[`status`](https://hl7.org/fhir/R4/medicationdispense.html#search)** search parameters:
     - **SHOULD** support chained searching of patient canonical identifier `patient.identifier` (e.g. `patient.identifier=[system|][code]`)
+    - **SHOULD** support these **[`_include`](http://hl7.org/fhir/R4/search.html#include)** parameters: `MedicationDispense:medication`
     - **SHALL** support *[multipleOr](http://hl7.org/fhir/R4/searchparameter-definitions.html#SearchParameter.multipleOr)* search on `status` (e.g. `status={system|}[code],{system|}[code],...`)
 
 
@@ -69,5 +72,6 @@ The following search parameters and search parameter combinations **SHOULD** be 
     Example:
     
       1. GET [base]/MedicationDispense?patient=5678&amp;status=completed
+      1. GET [base]/MedicationDispense?patient=5678&amp;status=completed&amp;_include=MedicationDispense:medication
 
     *Implementation Notes:* Fetches a bundle of all MedicationDispense resources for the specified patient and status ([how to search by reference](http://hl7.org/fhir/R4/search.html#reference) and [how to search by token](http://hl7.org/fhir/R4/search.html#token))

--- a/input/intro-notes/StructureDefinition-au-core-medicationdispense-notes.md
+++ b/input/intro-notes/StructureDefinition-au-core-medicationdispense-notes.md
@@ -31,7 +31,7 @@
         <td>prescription</td>
         <td><b>MAY</b></td>
         <td><code>reference</code></td>
-        <td>The requester <b>SHALL</b> provide at least an id value and <b>MAY</b> provide both the Type and id values. The responder <b>SHALL</b> support both.</td>
+        <td>The requester <b>SHALL</b> provide at least an id value and <b>MAY</b> provide both the type and id values. The responder <b>SHALL</b> support both.</td>
   </tr>
  </tbody>
 </table>

--- a/input/pagecontent/changes.md
+++ b/input/pagecontent/changes.md
@@ -6,12 +6,12 @@
 This change log documents the significant updates and resolutions implemented from version [3.0.0-ballot1](https://hl7.org.au/fhir/core/3.0.0-ballot1/index.html) to TBD. The list below includes substantive changes to mandatory and _Must Support_ elements inherited from AU Base.
 
 #### Changes in this version
-- [AU Core Requester CapabilityStatement](CapabilityStatement-au-core-requester.html) 
-  - added the existing AU Core reference search parameter requirements to supply type and id values to the MedicationDispense prescription search parameter [AU Core: FHIR-57858](https://jira.hl7.org/browse/FHIR-57858)
-  - added support for _include=MedicationDispense:medication as SHOULD, and where a responder references an external Medication resource as SHALL [AU Core: FHIR-57894](https://jira.hl7.org/browse/FHIR-57894)
-- [AU Core Responder CapabilityStatement](CapabilityStatement-au-core-responder.html)
-  - added the existing AU Core reference search parameter requirements to supply type and id values to the MedicationDispense prescription search parameter [AU Core: FHIR-57858](https://jira.hl7.org/browse/FHIR-57858)
-  - added support for _include=MedicationDispense:medication as SHOULD, and where a responder references an external Medication resource as SHALL [AU Core: FHIR-57894](https://jira.hl7.org/browse/FHIR-57894)
+- [AU Core Requester CapabilityStatement](CapabilityStatement-au-core-requester.html):
+  - added requirements for the MedicationDispense presription search parameter for the requester to provide an id value as SHALL and type value as MAY, and for the responder to support both as SHALL [AU Core: FHIR-57858](https://jira.hl7.org/browse/FHIR-57858)
+  - added support for _include=MedicationDispense:medication as SHOULD for requester and responder, and as SHALL for responder where an external Medication resource is referenced [AU Core: FHIR-57894](https://jira.hl7.org/browse/FHIR-57894)
+- [AU Core Responder CapabilityStatement](CapabilityStatement-au-core-responder.html):
+  - added requirements for the MedicationDispense presription search parameter for the requester to provide an id value as SHALL and type value as MAY, and for the responder to support both as SHALL [AU Core: FHIR-57858](https://jira.hl7.org/browse/FHIR-57858)
+  - added support for _include=MedicationDispense:medication as SHOULD for requester and responder, and as SHALL for responder where an external Medication resource is referenced [AU Core: FHIR-57894](https://jira.hl7.org/browse/FHIR-57894)
 
 ### Release 3.0.0-ballot1
 - Publication date: 2026-07-29

--- a/input/pagecontent/changes.md
+++ b/input/pagecontent/changes.md
@@ -6,8 +6,11 @@
 This change log documents the significant updates and resolutions implemented from version [3.0.0-ballot1](https://hl7.org.au/fhir/core/3.0.0-ballot1/index.html) to TBD. The list below includes substantive changes to mandatory and _Must Support_ elements inherited from AU Base.
 
 #### Changes in this version
-- [AU Core MedicationDispense](StructureDefinition-au-core-medicationdispense.html)
-  - added the existing AU Core reference search parameter requirements to supply type and id values to the 'prescription' search parameter [AU Core: FHIR-57858](https://jira.hl7.org/browse/FHIR-57858)
+- [AU Core Requester CapabilityStatement](CapabilityStatement-au-core-requester.html) 
+  - added the existing AU Core reference search parameter requirements to supply type and id values to the MedicationDispense'prescription' search parameter [AU Core: FHIR-57858](https://jira.hl7.org/browse/FHIR-57858)
+  - added support for _include=MedicationDispense:medication as SHOULD, and where a responder references an external Medication resource as SHALL [AU Core: FHIR-57894](https://jira.hl7.org/browse/FHIR-57894)
+- [AU Core Responder CapabilityStatement](CapabilityStatement-au-core-responder.html)
+  - added the existing AU Core reference search parameter requirements to supply type and id values to the MedicationDispense'prescription' search parameter [AU Core: FHIR-57858](https://jira.hl7.org/browse/FHIR-57858)
   - added support for _include=MedicationDispense:medication as SHOULD, and where a responder references an external Medication resource as SHALL [AU Core: FHIR-57894](https://jira.hl7.org/browse/FHIR-57894)
 
 ### Release 3.0.0-ballot1

--- a/input/pagecontent/changes.md
+++ b/input/pagecontent/changes.md
@@ -6,7 +6,9 @@
 This change log documents the significant updates and resolutions implemented from version [3.0.0-ballot1](https://hl7.org.au/fhir/core/3.0.0-ballot1/index.html) to TBD. The list below includes substantive changes to mandatory and _Must Support_ elements inherited from AU Base.
 
 #### Changes in this version
-
+- [AU Core MedicationDispense](StructureDefinition-au-core-medicationdispense.html)
+  - added the existing AU Core reference search parameter requirements to supply Type and id values to the 'prescription' search parameter [AU Core: FHIR-57858](https://jira.hl7.org/browse/FHIR-57858)
+  - added support for _include=MedicationDispense:medication as SHOULD, and where a responder references an external Medication resource as SHALL [AU Core: FHIR-57894](https://jira.hl7.org/browse/FHIR-57894)
 
 ### Release 3.0.0-ballot1
 - Publication date: 2026-07-29

--- a/input/pagecontent/changes.md
+++ b/input/pagecontent/changes.md
@@ -7,10 +7,10 @@ This change log documents the significant updates and resolutions implemented fr
 
 #### Changes in this version
 - [AU Core Requester CapabilityStatement](CapabilityStatement-au-core-requester.html) 
-  - added the existing AU Core reference search parameter requirements to supply type and id values to the MedicationDispense'prescription' search parameter [AU Core: FHIR-57858](https://jira.hl7.org/browse/FHIR-57858)
+  - added the existing AU Core reference search parameter requirements to supply type and id values to the MedicationDispense prescription search parameter [AU Core: FHIR-57858](https://jira.hl7.org/browse/FHIR-57858)
   - added support for _include=MedicationDispense:medication as SHOULD, and where a responder references an external Medication resource as SHALL [AU Core: FHIR-57894](https://jira.hl7.org/browse/FHIR-57894)
 - [AU Core Responder CapabilityStatement](CapabilityStatement-au-core-responder.html)
-  - added the existing AU Core reference search parameter requirements to supply type and id values to the MedicationDispense'prescription' search parameter [AU Core: FHIR-57858](https://jira.hl7.org/browse/FHIR-57858)
+  - added the existing AU Core reference search parameter requirements to supply type and id values to the MedicationDispense prescription search parameter [AU Core: FHIR-57858](https://jira.hl7.org/browse/FHIR-57858)
   - added support for _include=MedicationDispense:medication as SHOULD, and where a responder references an external Medication resource as SHALL [AU Core: FHIR-57894](https://jira.hl7.org/browse/FHIR-57894)
 
 ### Release 3.0.0-ballot1

--- a/input/pagecontent/changes.md
+++ b/input/pagecontent/changes.md
@@ -7,7 +7,7 @@ This change log documents the significant updates and resolutions implemented fr
 
 #### Changes in this version
 - [AU Core MedicationDispense](StructureDefinition-au-core-medicationdispense.html)
-  - added the existing AU Core reference search parameter requirements to supply Type and id values to the 'prescription' search parameter [AU Core: FHIR-57858](https://jira.hl7.org/browse/FHIR-57858)
+  - added the existing AU Core reference search parameter requirements to supply type and id values to the 'prescription' search parameter [AU Core: FHIR-57858](https://jira.hl7.org/browse/FHIR-57858)
   - added support for _include=MedicationDispense:medication as SHOULD, and where a responder references an external Medication resource as SHALL [AU Core: FHIR-57894](https://jira.hl7.org/browse/FHIR-57894)
 
 ### Release 3.0.0-ballot1

--- a/input/resources/au-core-requester.xml
+++ b/input/resources/au-core-requester.xml
@@ -1113,6 +1113,11 @@
 <type value="reference"/>
 <documentation value="The requester **SHALL** provide at least an id value and **MAY** provide both the type and id values.&#xa;&#xa;The responder **SHALL** support both."/>
 </searchParam>
+<searchInclude value="MedicationDispense:medication">
+<extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+<valueCode value="SHOULD"/>
+</extension>
+</searchInclude>
 </resource>
 <!-- MEDICATIONREQUEST :: DONE -->
 <resource>

--- a/input/resources/au-core-requester.xml
+++ b/input/resources/au-core-requester.xml
@@ -1112,7 +1112,7 @@
 <name value="prescription"/>
 <definition value="http://hl7.org/fhir/SearchParameter/medications-prescription"/>
 <type value="reference"/>
-<documentation value="The requester **SHALL** provide at least an id value and **MAY** provide both the Type and id values.&#xa;&#xa;The responder **SHALL** support both."/>
+<documentation value="The requester **SHALL** provide at least an id value and **MAY** provide both the type and id values.&#xa;&#xa;The responder **SHALL** support both."/>
 </searchParam>
 </resource>
 <!-- MEDICATIONREQUEST :: DONE -->

--- a/input/resources/au-core-requester.xml
+++ b/input/resources/au-core-requester.xml
@@ -1069,7 +1069,7 @@
 </extension>
 <type value="MedicationDispense"/>
 <profile value="http://hl7.org.au/fhir/core/StructureDefinition/au-core-medicationdispense"/>
-<documentation value="If the requester supports the MedicationDispense resource, the requester **SHALL** support the AU Core profile and the conformance expectations for the MedicationDispense resource.&#xA;&#xA; MedicationDispense resources can represent a medication using either a code or refer to the Medication resource. When referencing Medication, the resource may be [contained](http://hl7.org/fhir/R4/references.html#contained) or an external resource. The responder **MAY** choose any one way or more than one method. The requester application **SHALL** support all methods."/>
+<documentation value="If the requester supports the MedicationDispense resource, the requester **SHALL** support the AU Core profile and the conformance expectations for the MedicationDispense resource.&#xA;&#xA; MedicationDispense resources can represent a medication using either a code or refer to the Medication resource. When referencing Medication, the resource may be [contained](http://hl7.org/fhir/R4/references.html#contained) or an external resource. The responder **MAY** choose any one way or more than one method, but if an external reference to Medication is used, the responder **SHALL** support the `_include` parameter for searching this element. The requester application **SHALL** support all methods.&#xa;&#xa;The requester **SHOULD** support the `_include` parameter for `MedicationDispense:medication`. The responder **SHOULD** support the `_include` parameter for `MedicationDispense:medication`, but where a responder references external Medication resources the responder **SHALL** support the `_include` parameter."/>
 <interaction>
 <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
 <valueCode value="SHALL"/>
@@ -1112,6 +1112,7 @@
 <name value="prescription"/>
 <definition value="http://hl7.org/fhir/SearchParameter/medications-prescription"/>
 <type value="reference"/>
+<documentation value="The requester **SHALL** provide at least an id value and **MAY** provide both the Type and id values.&#xa;&#xa;The responder **SHALL** support both."/>
 </searchParam>
 </resource>
 <!-- MEDICATIONREQUEST :: DONE -->

--- a/input/resources/au-core-responder.xml
+++ b/input/resources/au-core-responder.xml
@@ -1109,7 +1109,7 @@
 <name value="prescription"/>
 <definition value="http://hl7.org/fhir/SearchParameter/medications-prescription"/>
 <type value="reference"/>
-<documentation value="The requester **SHALL** provide at least an id value and **MAY** provide both the Type and id values.&#xa;&#xa;The responder **SHALL** support both."/>
+<documentation value="The requester **SHALL** provide at least an id value and **MAY** provide both the type and id values.&#xa;&#xa;The responder **SHALL** support both."/>
 </searchParam>
 </resource>
 <!-- MEDICATIONREQUEST :: DONE -->

--- a/input/resources/au-core-responder.xml
+++ b/input/resources/au-core-responder.xml
@@ -1110,6 +1110,11 @@
 <type value="reference"/>
 <documentation value="The requester **SHALL** provide at least an id value and **MAY** provide both the type and id values.&#xa;&#xa;The responder **SHALL** support both."/>
 </searchParam>
+<searchInclude value="MedicationDispense:medication">
+<extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+<valueCode value="SHOULD"/>
+</extension>
+</searchInclude>
 </resource>
 <!-- MEDICATIONREQUEST :: DONE -->
 <resource>

--- a/input/resources/au-core-responder.xml
+++ b/input/resources/au-core-responder.xml
@@ -1066,7 +1066,7 @@
 </extension>
 <type value="MedicationDispense"/>
 <profile value="http://hl7.org.au/fhir/core/StructureDefinition/au-core-medicationdispense"/>
-<documentation value="If the responder supports the MedicationDispense resource, the responder **SHALL** support the AU Core profile and the conformance expectations for the MedicationDispense resource.&#xA;&#xA;MedicationDispense resources can represent a medication using either a code or refer to the Medication resource. When referencing Medication, the resource may be [contained](http://hl7.org/fhir/R4/references.html#contained) or an external resource. The responder **MAY** choose any one way or more than one method. The requester application **SHALL** support all methods."/>
+<documentation value="If the responder supports the MedicationDispense resource, the responder **SHALL** support the AU Core profile and the conformance expectations for the MedicationDispense resource.&#xA;&#xA;MedicationDispense resources can represent a medication using either a code or refer to the Medication resource. When referencing Medication, the resource may be [contained](http://hl7.org/fhir/R4/references.html#contained) or an external resource. The responder **MAY** choose any one way or more than one method, but if an external reference to Medication is used, the responder **SHALL** support the `_include` parameter for searching this element. The requester application **SHALL** support all methods.&#xa;&#xa;The responder **SHOULD** support the `_include` parameter for `MedicationDispense:medication`, but where a responder references external Medication resources the responder **SHALL** support the `_include` parameter. The requester **SHOULD** support the `_include` parameter for `MedicationDispense:medication`."/>
 <interaction>
 <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
 <valueCode value="SHALL"/>
@@ -1109,6 +1109,7 @@
 <name value="prescription"/>
 <definition value="http://hl7.org/fhir/SearchParameter/medications-prescription"/>
 <type value="reference"/>
+<documentation value="The requester **SHALL** provide at least an id value and **MAY** provide both the Type and id values.&#xa;&#xa;The responder **SHALL** support both."/>
 </searchParam>
 </resource>
 <!-- MEDICATIONREQUEST :: DONE -->


### PR DESCRIPTION
Applies [FHIR-57858](https://jira.hl7.org/browse/FHIR-57858) & [FHIR-57894](https://jira.hl7.org/browse/FHIR-57894)
* Apply AU Core reference search param requirements to MedicationDispense 'prescription' in CapStats and profile notes
* Apply existing approach for MedicationDispense:medication to profile specific implementation guidance, profile notes and CapStats
* Change log entries