### PR TITLE
Apply technical corrections from R3 ballot

### DIFF
--- a/input/intro-notes/StructureDefinition-au-core-allergyintolerance-notes.md
+++ b/input/intro-notes/StructureDefinition-au-core-allergyintolerance-notes.md
@@ -57,7 +57,7 @@ The following search parameters and search parameter combinations **SHOULD** be 
     - **SHOULD** support chained searching of patient canonical identifier `patient.identifier` (e.g. `patient.identifier=[system|][code]`)
 
 
-    `GET [base]/AllergyIntolerance?patient={Type/}[id]&clinical-status={system|}[code]{,{system|}[code],...}`
+    `GET [base]/AllergyIntolerance?patient={Type/}[id]&clinical-status={system|}[code]`
 
     Example:
     

--- a/input/intro-notes/StructureDefinition-au-core-documentreference-intro.md
+++ b/input/intro-notes/StructureDefinition-au-core-documentreference-intro.md
@@ -4,8 +4,8 @@ See [Comparison with other national and international IGs](comparison.html) for 
 
 The following are supported usage scenarios for this profile:
 
-- Query for documents belonging to a patient
-- Record or update a document belonging to a patient
+- Query for a patient's document
+- Record or update a patient's document
 
 ### Profile Specific Implementation Guidance
 - `DocumentReference.category` provides an efficient way of supporting system interactions, e.g. restricting searches. Implementers need to understand that data categorisation is somewhat subjective. The categorisation applied by the source may not align with a receiver’s expectations.

--- a/input/resources/au-core-requester.xml
+++ b/input/resources/au-core-requester.xml
@@ -8,7 +8,6 @@
 <name value="AUCoreRequesterCapabilityStatement"/>
 <title value="AU Core Requester CapabilityStatement"/>
 <status value="active"/>
-<date value="2023-05-15"/>
 <description value="This CapabilityStatement describes the basic rules for the [AU Core Requester actor](ActorDefinition-au-core-actor-requester.html) that is responsible for creating and initiating the queries for information. The complete list of FHIR profiles, RESTful operations, and search parameters supported by AU Core Requesters are defined in this CapabilityStatement."/>
 <kind value="requirements"/>
 <fhirVersion value="4.0.1"/>

--- a/input/resources/au-core-responder.xml
+++ b/input/resources/au-core-responder.xml
@@ -8,7 +8,6 @@
 <name value="AUCoreResponderCapabilityStatement"/>
 <title value="AU Core Responder CapabilityStatement"/>
 <status value="active"/>
-<date value="2023-05-15"/>
 <description value="This CapabilityStatement describes the basic rules for the [AU Core Responder actor](ActorDefinition-au-core-actor-responder.html) that is responsible for providing responses to queries submitted by AU Core Requesters. The complete list of FHIR profiles, RESTful operations, and search parameters supported by AU Core Responders are defined in this CapabilityStatement."/>
 <kind value="requirements"/>
 <fhirVersion value="4.0.1"/>


### PR DESCRIPTION
 This PR addresses https://jira.hl7.org/browse/FHIR-58725, https://jira.hl7.org/browse/FHIR-58709 and 
https://jira.hl7.org/browse/FHIR-58683.

Applies technical corrections identified during the AU Core R3 ballot review. Changes:
- remove the hard coded CapabilityStatement.date from the AU Core Responder adn Requester CapabilityStatements, allowing the build to populate the value
- correct the clinical-status search syntax in the AU Core AllergyIntolerance notes
- update AU Core DocumentReference usage scenarios to use standard AU Core language